### PR TITLE
Remove an errant message

### DIFF
--- a/lib/platform-api/client.rb
+++ b/lib/platform-api/client.rb
@@ -13013,7 +13013,7 @@ module PlatformAPI
           "targetSchema": {
             "$ref": "#/definitions/source"
           },
-          "title": "Create (Deprecated)"
+          "title": "Create Deprecated"
         }
       ],
       "properties": {


### PR DESCRIPTION
The "Create (Deprecated)" changes inside heroics to "create_(deprecated)" and Ruby freaks out that this is not a valid method name.

Obviously this endpoint is set to be removed in August of this year, but in order to get rails to start, we have to remove the () at the very least or else we get a stack error.