### PR TITLE
Update schema & generated client.rb

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,18 +8,14 @@ GEM
   remote: https://rubygems.org/
   specs:
     erubis (2.7.0)
-    excon (0.49.0)
-    heroics (0.0.17)
+    excon (0.55.0)
+    heroics (0.0.19)
       erubis (~> 2.0)
       excon
-      moneta
       multi_json (>= 1.9.2)
-      netrc
-    moneta (0.8.0)
     multi_json (1.12.1)
-    netrc (0.11.0)
-    rake (10.5.0)
-    yard (0.8.7.6)
+    rake (12.0.0)
+    yard (0.9.8)
 
 PLATFORMS
   ruby
@@ -31,4 +27,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.11.2
+   1.13.6

--- a/lib/platform-api/client.rb
+++ b/lib/platform-api/client.rb
@@ -111,46 +111,53 @@ module PlatformAPI
       @account_resource ||= Account.new(@client)
     end
 
-    # Add-on Actions are Provider functionality for specific add-on installations
+    # Add-on Actions are lifecycle operations for add-on provisioning and deprovisioning. They allow whitelisted add-on providers to (de)provision add-ons in the background and then report back when (de)provisioning is complete.
     #
-    # @return [AddonAction]
-    def addon_action
-      @addon_action_resource ||= AddonAction.new(@client)
+    # @return [AddOnAction]
+    def add_on_action
+      @add_on_action_resource ||= AddOnAction.new(@client)
     end
 
     # An add-on attachment represents a connection between an app and an add-on that it has been given access to.
     #
-    # @return [AddonAttachment]
-    def addon_attachment
-      @addon_attachment_resource ||= AddonAttachment.new(@client)
+    # @return [AddOnAttachment]
+    def add_on_attachment
+      @add_on_attachment_resource ||= AddOnAttachment.new(@client)
     end
 
     # Configuration of an Add-on
     #
-    # @return [AddonConfig]
-    def addon_config
-      @addon_config_resource ||= AddonConfig.new(@client)
+    # @return [AddOnConfig]
+    def add_on_config
+      @add_on_config_resource ||= AddOnConfig.new(@client)
+    end
+
+    # Add-on Plan Actions are Provider functionality for specific add-on installations
+    #
+    # @return [AddOnPlanAction]
+    def add_on_plan_action
+      @add_on_plan_action_resource ||= AddOnPlanAction.new(@client)
     end
 
     # Add-on region capabilities represent the relationship between an Add-on Service and a specific Region. Only Beta and GA add-ons are returned by these endpoints.
     #
-    # @return [AddonRegionCapability]
-    def addon_region_capability
-      @addon_region_capability_resource ||= AddonRegionCapability.new(@client)
+    # @return [AddOnRegionCapability]
+    def add_on_region_capability
+      @add_on_region_capability_resource ||= AddOnRegionCapability.new(@client)
     end
 
     # Add-on services represent add-ons that may be provisioned for apps. Endpoints under add-on services can be accessed without authentication.
     #
-    # @return [AddonService]
-    def addon_service
-      @addon_service_resource ||= AddonService.new(@client)
+    # @return [AddOnService]
+    def add_on_service
+      @add_on_service_resource ||= AddOnService.new(@client)
     end
 
     # Add-ons represent add-ons that have been provisioned and attached to one or more apps.
     #
-    # @return [Addon]
-    def addon
-      @addon_resource ||= Addon.new(@client)
+    # @return [AddOn]
+    def add_on
+      @add_on_resource ||= AddOn.new(@client)
     end
 
     # An app feature represents a Heroku labs capability that can be enabled or disabled for an app on Heroku.
@@ -158,6 +165,13 @@ module PlatformAPI
     # @return [AppFeature]
     def app_feature
       @app_feature_resource ||= AppFeature.new(@client)
+    end
+
+    # App formation set describes the combination of process types with their quantities and sizes as well as application process tier
+    #
+    # @return [AppFormationSet]
+    def app_formation_set
+      @app_formation_set_resource ||= AppFormationSet.new(@client)
     end
 
     # An app setup represents an app on Heroku that is setup using an environment, addons, and scripts described in an app.json manifest file.
@@ -230,6 +244,13 @@ module PlatformAPI
       @domain_resource ||= Domain.new(@client)
     end
 
+    # Dyno sizes are the values and details of sizes that can be assigned to dynos. This information can also be found at : [https://devcenter.heroku.com/articles/dyno-types](https://devcenter.heroku.com/articles/dyno-types).
+    #
+    # @return [DynoSize]
+    def dyno_size
+      @dyno_size_resource ||= DynoSize.new(@client)
+    end
+
     # Dynos encapsulate running processes of an app on Heroku. Detailed information about dyno sizes can be found at: [https://devcenter.heroku.com/articles/dyno-types](https://devcenter.heroku.com/articles/dyno-types).
     #
     # @return [Dyno]
@@ -263,6 +284,13 @@ module PlatformAPI
     # @return [Formation]
     def formation
       @formation_resource ||= Formation.new(@client)
+    end
+
+    # Identity Providers represent the SAML configuration of an Organization.
+    #
+    # @return [IdentityProvider]
+    def identity_provider
+      @identity_provider_resource ||= IdentityProvider.new(@client)
     end
 
     # An inbound-ruleset is a collection of rules that specify what hosts can or cannot connect to an application.
@@ -300,7 +328,7 @@ module PlatformAPI
       @key_resource ||= Key.new(@client)
     end
 
-    # [Log drains](https://devcenter.heroku.com/articles/log-drains) provide a way to forward your Heroku logs to an external syslog server for long-term archiving. This external service must be configured to receive syslog packets from Heroku, whereupon its URL can be added to an app using this API. Some addons will add a log drain when they are provisioned to an app. These drains can only be removed by removing the add-on.
+    # [Log drains](https://devcenter.heroku.com/articles/log-drains) provide a way to forward your Heroku logs to an external syslog server for long-term archiving. This external service must be configured to receive syslog packets from Heroku, whereupon its URL can be added to an app using this API. Some add-ons will add a log drain when they are provisioned to an app. These drains can only be removed by removing the add-on.
     #
     # @return [LogDrain]
     def log_drain
@@ -344,9 +372,9 @@ module PlatformAPI
 
     # A list of add-ons the Organization uses across all apps
     #
-    # @return [OrganizationAddon]
-    def organization_addon
-      @organization_addon_resource ||= OrganizationAddon.new(@client)
+    # @return [OrganizationAddOn]
+    def organization_add_on
+      @organization_add_on_resource ||= OrganizationAddOn.new(@client)
     end
 
     # An organization collaborator represents an account that has been given access to an organization app on Heroku.
@@ -363,6 +391,20 @@ module PlatformAPI
       @organization_app_resource ||= OrganizationApp.new(@client)
     end
 
+    # An organization feature represents a feature enabled on an organization account.
+    #
+    # @return [OrganizationFeature]
+    def organization_feature
+      @organization_feature_resource ||= OrganizationFeature.new(@client)
+    end
+
+    # An organization invitation represents an invite to an organization.
+    #
+    # @return [OrganizationInvitation]
+    def organization_invitation
+      @organization_invitation_resource ||= OrganizationInvitation.new(@client)
+    end
+
     # An organization invoice is an itemized bill of goods for an organization which includes pricing and charges.
     #
     # @return [OrganizationInvoice]
@@ -375,13 +417,6 @@ module PlatformAPI
     # @return [OrganizationMember]
     def organization_member
       @organization_member_resource ||= OrganizationMember.new(@client)
-    end
-
-    # The on file payment method for an organization account.
-    #
-    # @return [OrganizationPaymentMethod]
-    def organization_payment_method
-      @organization_payment_method_resource ||= OrganizationPaymentMethod.new(@client)
     end
 
     # Tracks an organization's preferences
@@ -398,13 +433,6 @@ module PlatformAPI
       @organization_resource ||= Organization.new(@client)
     end
 
-    # This renders a secret that clients can use to build a one-time password to be supplied as a 2nd factor of authentication.
-    #
-    # @return [OtpSecret]
-    def otp_secret
-      @otp_secret_resource ||= OtpSecret.new(@client)
-    end
-
     # An outbound-ruleset is a collection of rules that specify what hosts Dynos are allowed to communicate with. 
     #
     # @return [OutboundRuleset]
@@ -417,20 +445,6 @@ module PlatformAPI
     # @return [PasswordReset]
     def password_reset
       @password_reset_resource ||= PasswordReset.new(@client)
-    end
-
-    # The on file payment method for an account
-    #
-    # @return [PaymentMethod]
-    def payment_method
-      @payment_method_resource ||= PaymentMethod.new(@client)
-    end
-
-    # A payment represents money collected for an account
-    #
-    # @return [Payment]
-    def payment
-      @payment_resource ||= Payment.new(@client)
     end
 
     # An organization app permission is a behavior that is assigned to a user in an organization app.
@@ -482,13 +496,6 @@ module PlatformAPI
       @rate_limit_resource ||= RateLimit.new(@client)
     end
 
-    # Recovery codes grant access to accounts with two-factor authentication enabled.
-    #
-    # @return [RecoveryCode]
-    def recovery_code
-      @recovery_code_resource ||= RecoveryCode.new(@client)
-    end
-
     # A region represents a geographic location in which your application may run.
     #
     # @return [Region]
@@ -515,6 +522,13 @@ module PlatformAPI
     # @return [SmsNumber]
     def sms_number
       @sms_number_resource ||= SmsNumber.new(@client)
+    end
+
+    # SNI Endpoint is a public address serving a custom SSL cert for HTTPS traffic, using the SNI TLS extension, to a Heroku app. Note: only apps with the `http-sni` and `stable-cname` feature flags or those owned by a user with the `user-http-sni` and `user-stable-cname` feature flags are authorized to use this endpoint.
+    #
+    # @return [SniEndpoint]
+    def sni_endpoint
+      @sni_endpoint_resource ||= SniEndpoint.new(@client)
     end
 
     # A source is a location for uploading and downloading an application's source code.
@@ -545,7 +559,7 @@ module PlatformAPI
       @space_resource ||= Space.new(@client)
     end
 
-    # [SSL Endpoint](https://devcenter.heroku.com/articles/ssl-endpoint) is a public address serving custom SSL cert for HTTPS traffic to a Heroku app. Note that an app must have the `ssl:endpoint` addon installed before it can provision an SSL Endpoint using these APIs.
+    # [SSL Endpoint](https://devcenter.heroku.com/articles/ssl-endpoint) is a public address serving custom SSL cert for HTTPS traffic to a Heroku app. Note that an app must have the `ssl:endpoint` add-on installed before it can provision an SSL Endpoint using these APIs.
     #
     # @return [SSLEndpoint]
     def ssl_endpoint
@@ -568,16 +582,9 @@ module PlatformAPI
 
     # Entities that have been whitelisted to be used by an Organization
     #
-    # @return [WhitelistedAddonService]
-    def whitelisted_addon_service
-      @whitelisted_addon_service_resource ||= WhitelistedAddonService.new(@client)
-    end
-
-    # SNI Endpoint is a public address serving a custom SSL cert for HTTPS traffic, using the SNI TLS extension, to a Heroku app. Note: only apps with the `http-sni` and `stable-cname` feature flags or those owned by a user with the `user-http-sni` and `user-stable-cname` feature flags are authorized to use this endpoint.
-    #
-    # @return [SniEndpoint]
-    def sni_endpoint
-      @sni_endpoint_resource ||= SniEndpoint.new(@client)
+    # @return [WhitelistedAddOnService]
+    def whitelisted_add_on_service
+      @whitelisted_add_on_service_resource ||= WhitelistedAddOnService.new(@client)
     end
   end
 
@@ -631,22 +638,6 @@ module PlatformAPI
       @client.account.update(account_email_or_account_id_or_account_self, body)
     end
 
-    # Change Email for account.
-    #
-    # @param account_email_or_account_id_or_account_self: unique email address of account or unique identifier of an account or Implicit reference to currently authorized user
-    # @param body: the object to pass as the request payload
-    def change_email(account_email_or_account_id_or_account_self, body = {})
-      @client.account.change_email(account_email_or_account_id_or_account_self, body)
-    end
-
-    # Change Password for account.
-    #
-    # @param account_email_or_account_id_or_account_self: unique email address of account or unique identifier of an account or Implicit reference to currently authorized user
-    # @param body: the object to pass as the request payload
-    def change_password(account_email_or_account_id_or_account_self, body = {})
-      @client.account.change_password(account_email_or_account_id_or_account_self, body)
-    end
-
     # Delete account. Note that this action cannot be undone.
     #
     # @param account_email_or_account_id_or_account_self: unique email address of account or unique identifier of an account or Implicit reference to currently authorized user
@@ -655,15 +646,29 @@ module PlatformAPI
     end
   end
 
-  # Add-on Actions are Provider functionality for specific add-on installations
-  class AddonAction
+  # Add-on Actions are lifecycle operations for add-on provisioning and deprovisioning. They allow whitelisted add-on providers to (de)provision add-ons in the background and then report back when (de)provisioning is complete.
+  class AddOnAction
     def initialize(client)
       @client = client
+    end
+
+    # Mark an add-on as provisioned for use.
+    #
+    # @param add_on_id_or_add_on_name: unique identifier of add-on or globally unique name of the add-on
+    def create_provision(add_on_id_or_add_on_name)
+      @client.add_on_action.create_provision(add_on_id_or_add_on_name)
+    end
+
+    # Mark an add-on as deprovisioned.
+    #
+    # @param add_on_id_or_add_on_name: unique identifier of add-on or globally unique name of the add-on
+    def create_deprovision(add_on_id_or_add_on_name)
+      @client.add_on_action.create_deprovision(add_on_id_or_add_on_name)
     end
   end
 
   # An add-on attachment represents a connection between an app and an add-on that it has been given access to.
-  class AddonAttachment
+  class AddOnAttachment
     def initialize(client)
       @client = client
     end
@@ -672,75 +677,82 @@ module PlatformAPI
     #
     # @param body: the object to pass as the request payload
     def create(body = {})
-      @client.addon_attachment.create(body)
+      @client.add_on_attachment.create(body)
     end
 
     # Delete an existing add-on attachment.
     #
-    # @param addon_attachment_id: unique identifier of this add-on attachment
-    def delete(addon_attachment_id)
-      @client.addon_attachment.delete(addon_attachment_id)
+    # @param add_on_attachment_id: unique identifier of this add-on attachment
+    def delete(add_on_attachment_id)
+      @client.add_on_attachment.delete(add_on_attachment_id)
     end
 
     # Info for existing add-on attachment.
     #
-    # @param addon_attachment_id: unique identifier of this add-on attachment
-    def info(addon_attachment_id)
-      @client.addon_attachment.info(addon_attachment_id)
+    # @param add_on_attachment_id: unique identifier of this add-on attachment
+    def info(add_on_attachment_id)
+      @client.add_on_attachment.info(add_on_attachment_id)
     end
 
     # List existing add-on attachments.
     def list()
-      @client.addon_attachment.list()
+      @client.add_on_attachment.list()
     end
 
     # List existing add-on attachments for an add-on.
     #
-    # @param addon_id_or_addon_name: unique identifier of add-on or globally unique name of the add-on
-    def list_by_add_on(addon_id_or_addon_name)
-      @client.addon_attachment.list_by_add_on(addon_id_or_addon_name)
+    # @param add_on_id_or_add_on_name: unique identifier of add-on or globally unique name of the add-on
+    def list_by_add_on(add_on_id_or_add_on_name)
+      @client.add_on_attachment.list_by_add_on(add_on_id_or_add_on_name)
     end
 
     # List existing add-on attachments for an app.
     #
     # @param app_id_or_app_name: unique identifier of app or unique name of app
     def list_by_app(app_id_or_app_name)
-      @client.addon_attachment.list_by_app(app_id_or_app_name)
+      @client.add_on_attachment.list_by_app(app_id_or_app_name)
     end
 
     # Info for existing add-on attachment for an app.
     #
     # @param app_id_or_app_name: unique identifier of app or unique name of app
-    # @param addon_attachment_id_or_addon_attachment_name: unique identifier of this add-on attachment or unique name for this add-on attachment to this app
-    def info_by_app(app_id_or_app_name, addon_attachment_id_or_addon_attachment_name)
-      @client.addon_attachment.info_by_app(app_id_or_app_name, addon_attachment_id_or_addon_attachment_name)
+    # @param add_on_attachment_id_or_add_on_attachment_name: unique identifier of this add-on attachment or unique name for this add-on attachment to this app
+    def info_by_app(app_id_or_app_name, add_on_attachment_id_or_add_on_attachment_name)
+      @client.add_on_attachment.info_by_app(app_id_or_app_name, add_on_attachment_id_or_add_on_attachment_name)
     end
   end
 
   # Configuration of an Add-on
-  class AddonConfig
+  class AddOnConfig
     def initialize(client)
       @client = client
     end
 
-    # Get an add-on's config
+    # Get an add-on's config. Accessible by customers with access and by the add-on partner providing this add-on.
     #
-    # @param addon_id_or_addon_name: unique identifier of add-on or globally unique name of the add-on
-    def list(addon_id_or_addon_name)
-      @client.addon_config.list(addon_id_or_addon_name)
+    # @param add_on_id_or_add_on_name: unique identifier of add-on or globally unique name of the add-on
+    def list(add_on_id_or_add_on_name)
+      @client.add_on_config.list(add_on_id_or_add_on_name)
     end
 
-    # Update an add-on's config.
+    # Update an add-on's config. Can only be accessed by the add-on partner providing this add-on.
     #
-    # @param addon_id_or_addon_name: unique identifier of add-on or globally unique name of the add-on
+    # @param add_on_id_or_add_on_name: unique identifier of add-on or globally unique name of the add-on
     # @param body: the object to pass as the request payload
-    def update(addon_id_or_addon_name, body = {})
-      @client.addon_config.update(addon_id_or_addon_name, body)
+    def update(add_on_id_or_add_on_name, body = {})
+      @client.add_on_config.update(add_on_id_or_add_on_name, body)
+    end
+  end
+
+  # Add-on Plan Actions are Provider functionality for specific add-on installations
+  class AddOnPlanAction
+    def initialize(client)
+      @client = client
     end
   end
 
   # Add-on region capabilities represent the relationship between an Add-on Service and a specific Region. Only Beta and GA add-ons are returned by these endpoints.
-  class AddonRegionCapability
+  class AddOnRegionCapability
     def initialize(client)
       @client = client
     end
@@ -749,38 +761,38 @@ module PlatformAPI
     #
     # @param region_id_or_region_name: unique identifier of region or unique name of region
     def list(region_id_or_region_name)
-      @client.addon_region_capability.list(region_id_or_region_name)
+      @client.add_on_region_capability.list(region_id_or_region_name)
     end
 
-    # List existing add-on region capabilities for an addon-service
+    # List existing add-on region capabilities for an add-on-service
     #
-    # @param addon_service_id_or_addon_service_name: unique identifier of this addon-service or unique name of this addon-service
-    def list_by_add_on_service(addon_service_id_or_addon_service_name)
-      @client.addon_region_capability.list_by_add_on_service(addon_service_id_or_addon_service_name)
+    # @param add_on_service_id_or_add_on_service_name: unique identifier of this add-on-service or unique name of this add-on-service
+    def list_by_add_on_service(add_on_service_id_or_add_on_service_name)
+      @client.add_on_region_capability.list_by_add_on_service(add_on_service_id_or_add_on_service_name)
     end
   end
 
   # Add-on services represent add-ons that may be provisioned for apps. Endpoints under add-on services can be accessed without authentication.
-  class AddonService
+  class AddOnService
     def initialize(client)
       @client = client
     end
 
-    # Info for existing addon-service.
+    # Info for existing add-on-service.
     #
-    # @param addon_service_id_or_addon_service_name: unique identifier of this addon-service or unique name of this addon-service
-    def info(addon_service_id_or_addon_service_name)
-      @client.addon_service.info(addon_service_id_or_addon_service_name)
+    # @param add_on_service_id_or_add_on_service_name: unique identifier of this add-on-service or unique name of this add-on-service
+    def info(add_on_service_id_or_add_on_service_name)
+      @client.add_on_service.info(add_on_service_id_or_add_on_service_name)
     end
 
-    # List existing addon-services.
+    # List existing add-on-services.
     def list()
-      @client.addon_service.list()
+      @client.add_on_service.list()
     end
   end
 
   # Add-ons represent add-ons that have been provisioned and attached to one or more apps.
-  class Addon
+  class AddOn
     def initialize(client)
       @client = client
     end
@@ -790,50 +802,50 @@ module PlatformAPI
     # @param app_id_or_app_name: unique identifier of app or unique name of app
     # @param body: the object to pass as the request payload
     def create(app_id_or_app_name, body = {})
-      @client.addon.create(app_id_or_app_name, body)
+      @client.add_on.create(app_id_or_app_name, body)
     end
 
     # Delete an existing add-on.
     #
     # @param app_id_or_app_name: unique identifier of app or unique name of app
-    # @param addon_id_or_addon_name: unique identifier of add-on or globally unique name of the add-on
-    def delete(app_id_or_app_name, addon_id_or_addon_name)
-      @client.addon.delete(app_id_or_app_name, addon_id_or_addon_name)
+    # @param add_on_id_or_add_on_name: unique identifier of add-on or globally unique name of the add-on
+    def delete(app_id_or_app_name, add_on_id_or_add_on_name)
+      @client.add_on.delete(app_id_or_app_name, add_on_id_or_add_on_name)
     end
 
     # Info for an existing add-on.
     #
-    # @param addon_id_or_addon_name: unique identifier of add-on or globally unique name of the add-on
-    def info(addon_id_or_addon_name)
-      @client.addon.info(addon_id_or_addon_name)
+    # @param add_on_id_or_add_on_name: unique identifier of add-on or globally unique name of the add-on
+    def info(add_on_id_or_add_on_name)
+      @client.add_on.info(add_on_id_or_add_on_name)
     end
 
     # List all existing add-ons.
     def list()
-      @client.addon.list()
+      @client.add_on.list()
     end
 
     # List all existing add-ons a user has access to
     #
     # @param account_email_or_account_id_or_account_self: unique email address of account or unique identifier of an account or Implicit reference to currently authorized user
     def list_by_user(account_email_or_account_id_or_account_self)
-      @client.addon.list_by_user(account_email_or_account_id_or_account_self)
+      @client.add_on.list_by_user(account_email_or_account_id_or_account_self)
     end
 
     # List existing add-ons for an app.
     #
     # @param app_id_or_app_name: unique identifier of app or unique name of app
     def list_by_app(app_id_or_app_name)
-      @client.addon.list_by_app(app_id_or_app_name)
+      @client.add_on.list_by_app(app_id_or_app_name)
     end
 
     # Change add-on plan. Some add-ons may not support changing plans. In that case, an error will be returned.
     #
     # @param app_id_or_app_name: unique identifier of app or unique name of app
-    # @param addon_id_or_addon_name: unique identifier of add-on or globally unique name of the add-on
+    # @param add_on_id_or_add_on_name: unique identifier of add-on or globally unique name of the add-on
     # @param body: the object to pass as the request payload
-    def update(app_id_or_app_name, addon_id_or_addon_name, body = {})
-      @client.addon.update(app_id_or_app_name, addon_id_or_addon_name, body)
+    def update(app_id_or_app_name, add_on_id_or_add_on_name, body = {})
+      @client.add_on.update(app_id_or_app_name, add_on_id_or_add_on_name, body)
     end
   end
 
@@ -865,6 +877,13 @@ module PlatformAPI
     # @param body: the object to pass as the request payload
     def update(app_id_or_app_name, app_feature_id_or_app_feature_name, body = {})
       @client.app_feature.update(app_id_or_app_name, app_feature_id_or_app_feature_name, body)
+    end
+  end
+
+  # App formation set describes the combination of process types with their quantities and sizes as well as application process tier
+  class AppFormationSet
+    def initialize(client)
+      @client = client
     end
   end
 
@@ -1092,8 +1111,16 @@ module PlatformAPI
     # Get config-vars for app.
     #
     # @param app_id_or_app_name: unique identifier of app or unique name of app
-    def info(app_id_or_app_name)
-      @client.config_var.info(app_id_or_app_name)
+    def info_for_app(app_id_or_app_name)
+      @client.config_var.info_for_app(app_id_or_app_name)
+    end
+
+    # Get config-vars for a release.
+    #
+    # @param app_id_or_app_name: unique identifier of app or unique name of app
+    # @param release_id_or_release_version: unique identifier of release or unique version assigned to the release
+    def info_for_app_release(app_id_or_app_name, release_id_or_release_version)
+      @client.config_var.info_for_app_release(app_id_or_app_name, release_id_or_release_version)
     end
 
     # Update config-vars for app. You can update existing config-vars by setting them again, and remove by setting it to `null`.
@@ -1169,6 +1196,25 @@ module PlatformAPI
     end
   end
 
+  # Dyno sizes are the values and details of sizes that can be assigned to dynos. This information can also be found at : [https://devcenter.heroku.com/articles/dyno-types](https://devcenter.heroku.com/articles/dyno-types).
+  class DynoSize
+    def initialize(client)
+      @client = client
+    end
+
+    # Info for existing dyno size.
+    #
+    # @param dyno_size_id_or_dyno_size_name: unique identifier of this dyno size or the name of this dyno-size
+    def info(dyno_size_id_or_dyno_size_name)
+      @client.dyno_size.info(dyno_size_id_or_dyno_size_name)
+    end
+
+    # List existing dyno sizes.
+    def list()
+      @client.dyno_size.list()
+    end
+  end
+
   # Dynos encapsulate running processes of an app on Heroku. Detailed information about dyno sizes can be found at: [https://devcenter.heroku.com/articles/dyno-types](https://devcenter.heroku.com/articles/dyno-types).
   class Dyno
     def initialize(client)
@@ -1191,11 +1237,19 @@ module PlatformAPI
       @client.dyno.restart(app_id_or_app_name, dyno_id_or_dyno_name)
     end
 
-    # Restart all dynos
+    # Restart all dynos.
     #
     # @param app_id_or_app_name: unique identifier of app or unique name of app
     def restart_all(app_id_or_app_name)
       @client.dyno.restart_all(app_id_or_app_name)
+    end
+
+    # Stop dyno.
+    #
+    # @param app_id_or_app_name: unique identifier of app or unique name of app
+    # @param dyno_id_or_dyno_name: unique identifier of this dyno or the name of this process on this dyno
+    def stop(app_id_or_app_name, dyno_id_or_dyno_name)
+      @client.dyno.stop(app_id_or_app_name, dyno_id_or_dyno_name)
     end
 
     # Info for existing dyno.
@@ -1281,6 +1335,45 @@ module PlatformAPI
     end
   end
 
+  # Identity Providers represent the SAML configuration of an Organization.
+  class IdentityProvider
+    def initialize(client)
+      @client = client
+    end
+
+    # Get a list of an organization's Identity Providers
+    #
+    # @param organization_name: unique name of organization
+    def list(organization_name)
+      @client.identity_provider.list(organization_name)
+    end
+
+    # Create an Identity Provider for an organization
+    #
+    # @param organization_name: unique name of organization
+    # @param body: the object to pass as the request payload
+    def create(organization_name, body = {})
+      @client.identity_provider.create(organization_name, body)
+    end
+
+    # Update an organization's Identity Provider
+    #
+    # @param organization_name: unique name of organization
+    # @param identity_provider_id: unique identifier of this identity provider
+    # @param body: the object to pass as the request payload
+    def update(organization_name, identity_provider_id, body = {})
+      @client.identity_provider.update(organization_name, identity_provider_id, body)
+    end
+
+    # Delete an organization's Identity Provider
+    #
+    # @param organization_name: unique name of organization
+    # @param identity_provider_id: unique identifier of this identity provider
+    def delete(organization_name, identity_provider_id)
+      @client.identity_provider.delete(organization_name, identity_provider_id)
+    end
+  end
+
   # An inbound-ruleset is a collection of rules that specify what hosts can or cannot connect to an application.
   class InboundRuleset
     def initialize(client)
@@ -1324,19 +1417,35 @@ module PlatformAPI
       @client.invitation.info(invitation_token)
     end
 
+    # Invite a user.
+    #
+    # @param body: the object to pass as the request payload
+    def create(body = {})
+      @client.invitation.create(body)
+    end
+
+    # Send a verification code for an invitation via SMS/phone call.
+    #
+    # @param invitation_token: Unique identifier of an invitation
+    # @param body: the object to pass as the request payload
+    def send_verification_code(invitation_token, body = {})
+      @client.invitation.send_verification_code(invitation_token, body)
+    end
+
+    # Verify an invitation using a verification code.
+    #
+    # @param invitation_token: Unique identifier of an invitation
+    # @param body: the object to pass as the request payload
+    def verify(invitation_token, body = {})
+      @client.invitation.verify(invitation_token, body)
+    end
+
     # Finalize Invitation and Create Account.
     #
     # @param invitation_token: Unique identifier of an invitation
     # @param body: the object to pass as the request payload
-    def finalize_invitation(invitation_token, body = {})
-      @client.invitation.finalize_invitation(invitation_token, body)
-    end
-
-    # Invite a user.
-    #
-    # @param body: the object to pass as the request payload
-    def invitation(body = {})
-      @client.invitation.invitation(body)
+    def finalize(invitation_token, body = {})
+      @client.invitation.finalize(invitation_token, body)
     end
   end
 
@@ -1384,20 +1493,6 @@ module PlatformAPI
       @client = client
     end
 
-    # Create a new key.
-    #
-    # @param body: the object to pass as the request payload
-    def create(body = {})
-      @client.key.create(body)
-    end
-
-    # Delete an existing key
-    #
-    # @param key_id_or_key_fingerprint: unique identifier of this key or a unique identifying string based on contents
-    def delete(key_id_or_key_fingerprint)
-      @client.key.delete(key_id_or_key_fingerprint)
-    end
-
     # Info for existing key.
     #
     # @param key_id_or_key_fingerprint: unique identifier of this key or a unique identifying string based on contents
@@ -1411,7 +1506,7 @@ module PlatformAPI
     end
   end
 
-  # [Log drains](https://devcenter.heroku.com/articles/log-drains) provide a way to forward your Heroku logs to an external syslog server for long-term archiving. This external service must be configured to receive syslog packets from Heroku, whereupon its URL can be added to an app using this API. Some addons will add a log drain when they are provisioned to an app. These drains can only be removed by removing the add-on.
+  # [Log drains](https://devcenter.heroku.com/articles/log-drains) provide a way to forward your Heroku logs to an external syslog server for long-term archiving. This external service must be configured to receive syslog packets from Heroku, whereupon its URL can be added to an app using this API. Some add-ons will add a log drain when they are provisioned to an app. These drains can only be removed by removing the add-on.
   class LogDrain
     def initialize(client)
       @client = client
@@ -1581,7 +1676,7 @@ module PlatformAPI
   end
 
   # A list of add-ons the Organization uses across all apps
-  class OrganizationAddon
+  class OrganizationAddOn
     def initialize(client)
       @client = client
     end
@@ -1590,7 +1685,7 @@ module PlatformAPI
     #
     # @param organization_name_or_organization_id: unique name of organization or unique identifier of organization
     def list_for_organization(organization_name_or_organization_id)
-      @client.organization_addon.list_for_organization(organization_name_or_organization_id)
+      @client.organization_add_on.list_for_organization(organization_name_or_organization_id)
     end
   end
 
@@ -1697,6 +1792,72 @@ module PlatformAPI
     end
   end
 
+  # An organization feature represents a feature enabled on an organization account.
+  class OrganizationFeature
+    def initialize(client)
+      @client = client
+    end
+
+    # Info for an existing account feature.
+    #
+    # @param organization_name_or_organization_id: unique name of organization or unique identifier of organization
+    # @param organization_feature_id_or_organization_feature_name: unique identifier of organization feature or unique name of organization feature
+    def info(organization_name_or_organization_id, organization_feature_id_or_organization_feature_name)
+      @client.organization_feature.info(organization_name_or_organization_id, organization_feature_id_or_organization_feature_name)
+    end
+
+    # List existing organization features.
+    #
+    # @param organization_name_or_organization_id: unique name of organization or unique identifier of organization
+    def list(organization_name_or_organization_id)
+      @client.organization_feature.list(organization_name_or_organization_id)
+    end
+  end
+
+  # An organization invitation represents an invite to an organization.
+  class OrganizationInvitation
+    def initialize(client)
+      @client = client
+    end
+
+    # Get a list of an organization's Identity Providers
+    #
+    # @param organization_name: unique name of organization
+    def list(organization_name)
+      @client.organization_invitation.list(organization_name)
+    end
+
+    # Create Organization Invitation
+    #
+    # @param organization_name_or_organization_id: unique name of organization or unique identifier of organization
+    # @param body: the object to pass as the request payload
+    def create(organization_name_or_organization_id, body = {})
+      @client.organization_invitation.create(organization_name_or_organization_id, body)
+    end
+
+    # Revoke an organization invitation.
+    #
+    # @param organization_name_or_organization_id: unique name of organization or unique identifier of organization
+    # @param organization_invitation_id: Unique identifier of an invitation
+    def revoke(organization_name_or_organization_id, organization_invitation_id)
+      @client.organization_invitation.revoke(organization_name_or_organization_id, organization_invitation_id)
+    end
+
+    # Get an invitation by its token
+    #
+    # @param organization_invitation_token: Special token for invitation
+    def get(organization_invitation_token)
+      @client.organization_invitation.get(organization_invitation_token)
+    end
+
+    # Accept Organization Invitation
+    #
+    # @param organization_invitation_token: Special token for invitation
+    def accept(organization_invitation_token)
+      @client.organization_invitation.accept(organization_invitation_token)
+    end
+  end
+
   # An organization invoice is an itemized bill of goods for an organization which includes pricing and charges.
   class OrganizationInvoice
     def initialize(client)
@@ -1733,6 +1894,22 @@ module PlatformAPI
       @client.organization_member.create_or_update(organization_name_or_organization_id, body)
     end
 
+    # Create a new organization member.
+    #
+    # @param organization_name_or_organization_id: unique name of organization or unique identifier of organization
+    # @param body: the object to pass as the request payload
+    def create(organization_name_or_organization_id, body = {})
+      @client.organization_member.create(organization_name_or_organization_id, body)
+    end
+
+    # Update an organization member.
+    #
+    # @param organization_name_or_organization_id: unique name of organization or unique identifier of organization
+    # @param body: the object to pass as the request payload
+    def update(organization_name_or_organization_id, body = {})
+      @client.organization_member.update(organization_name_or_organization_id, body)
+    end
+
     # Remove a member from the organization.
     #
     # @param organization_name_or_organization_id: unique name of organization or unique identifier of organization
@@ -1741,33 +1918,12 @@ module PlatformAPI
       @client.organization_member.delete(organization_name_or_organization_id, organization_member_email_or_organization_member_id)
     end
 
-    # List members of the organization.
+    # List the apps of a member.
     #
     # @param organization_name_or_organization_id: unique name of organization or unique identifier of organization
-    def list(organization_name_or_organization_id)
-      @client.organization_member.list(organization_name_or_organization_id)
-    end
-  end
-
-  # The on file payment method for an organization account.
-  class OrganizationPaymentMethod
-    def initialize(client)
-      @client = client
-    end
-
-    # Update an existing payment method for an organization account.
-    #
-    # @param organization_name_or_organization_id: unique name of organization or unique identifier of organization
-    # @param body: the object to pass as the request payload
-    def update(organization_name_or_organization_id, body = {})
-      @client.organization_payment_method.update(organization_name_or_organization_id, body)
-    end
-
-    # Get the current payment method for an organization account.
-    #
-    # @param organization_name_or_organization_id: unique name of organization or unique identifier of organization
-    def get(organization_name_or_organization_id)
-      @client.organization_payment_method.get(organization_name_or_organization_id)
+    # @param organization_member_email_or_organization_member_id: email address of the organization member or unique identifier of organization member
+    def list(organization_name_or_organization_id, organization_member_email_or_organization_member_id)
+      @client.organization_member.list(organization_name_or_organization_id, organization_member_email_or_organization_member_id)
     end
   end
 
@@ -1811,7 +1967,7 @@ module PlatformAPI
       @client.organization.info(organization_name_or_organization_id)
     end
 
-    # Set or unset the organization as your default organization.
+    # Update organization properties.
     #
     # @param organization_name_or_organization_id: unique name of organization or unique identifier of organization
     # @param body: the object to pass as the request payload
@@ -1831,18 +1987,6 @@ module PlatformAPI
     # @param organization_name_or_organization_id: unique name of organization or unique identifier of organization
     def delete(organization_name_or_organization_id)
       @client.organization.delete(organization_name_or_organization_id)
-    end
-  end
-
-  # This renders a secret that clients can use to build a one-time password to be supplied as a 2nd factor of authentication.
-  class OtpSecret
-    def initialize(client)
-      @client = client
-    end
-
-    # Create new OTP secret. This invalidates any existing OTP secrets on the account.
-    def create()
-      @client.otp_secret.create()
     end
   end
 
@@ -1895,39 +2039,6 @@ module PlatformAPI
     # @param body: the object to pass as the request payload
     def complete_reset_password(password_reset_reset_password_token, body = {})
       @client.password_reset.complete_reset_password(password_reset_reset_password_token, body)
-    end
-  end
-
-  # The on file payment method for an account
-  class PaymentMethod
-    def initialize(client)
-      @client = client
-    end
-
-    # Update an existing payment method for an account.
-    #
-    # @param body: the object to pass as the request payload
-    def update(body = {})
-      @client.payment_method.update(body)
-    end
-
-    # Get the current payment method for an account.
-    def get()
-      @client.payment_method.get()
-    end
-  end
-
-  # A payment represents money collected for an account
-  class Payment
-    def initialize(client)
-      @client = client
-    end
-
-    # Create a payment on an existing account
-    #
-    # @param body: the object to pass as the request payload
-    def create(body = {})
-      @client.payment.create(body)
     end
   end
 
@@ -2068,17 +2179,17 @@ module PlatformAPI
 
     # Info for existing plan.
     #
-    # @param addon_service_id_or_addon_service_name: unique identifier of this addon-service or unique name of this addon-service
+    # @param add_on_service_id_or_add_on_service_name: unique identifier of this add-on-service or unique name of this add-on-service
     # @param plan_id_or_plan_name: unique identifier of this plan or unique name of this plan
-    def info(addon_service_id_or_addon_service_name, plan_id_or_plan_name)
-      @client.plan.info(addon_service_id_or_addon_service_name, plan_id_or_plan_name)
+    def info(add_on_service_id_or_add_on_service_name, plan_id_or_plan_name)
+      @client.plan.info(add_on_service_id_or_add_on_service_name, plan_id_or_plan_name)
     end
 
     # List existing plans.
     #
-    # @param addon_service_id_or_addon_service_name: unique identifier of this addon-service or unique name of this addon-service
-    def list(addon_service_id_or_addon_service_name)
-      @client.plan.list(addon_service_id_or_addon_service_name)
+    # @param add_on_service_id_or_add_on_service_name: unique identifier of this add-on-service or unique name of this add-on-service
+    def list(add_on_service_id_or_add_on_service_name)
+      @client.plan.list(add_on_service_id_or_add_on_service_name)
     end
   end
 
@@ -2091,18 +2202,6 @@ module PlatformAPI
     # Info for rate limits.
     def info()
       @client.rate_limit.info()
-    end
-  end
-
-  # Recovery codes grant access to accounts with two-factor authentication enabled.
-  class RecoveryCode
-    def initialize(client)
-      @client = client
-    end
-
-    # Generate new recovery codes. This invalidates any existing codes on the account.
-    def create()
-      @client.recovery_code.create()
     end
   end
 
@@ -2214,17 +2313,69 @@ module PlatformAPI
     end
   end
 
+  # SNI Endpoint is a public address serving a custom SSL cert for HTTPS traffic, using the SNI TLS extension, to a Heroku app. Note: only apps with the `http-sni` and `stable-cname` feature flags or those owned by a user with the `user-http-sni` and `user-stable-cname` feature flags are authorized to use this endpoint.
+  class SniEndpoint
+    def initialize(client)
+      @client = client
+    end
+
+    # Create a new SNI endpoint.
+    #
+    # @param app_id_or_app_name: unique identifier of app or unique name of app
+    # @param body: the object to pass as the request payload
+    def create(app_id_or_app_name, body = {})
+      @client.sni_endpoint.create(app_id_or_app_name, body)
+    end
+
+    # Delete existing SNI endpoint.
+    #
+    # @param app_id_or_app_name: unique identifier of app or unique name of app
+    # @param sni_endpoint_id_or_sni_endpoint_name: unique identifier of this SNI endpoint or unique name for SNI endpoint
+    def delete(app_id_or_app_name, sni_endpoint_id_or_sni_endpoint_name)
+      @client.sni_endpoint.delete(app_id_or_app_name, sni_endpoint_id_or_sni_endpoint_name)
+    end
+
+    # Info for existing SNI endpoint.
+    #
+    # @param app_id_or_app_name: unique identifier of app or unique name of app
+    # @param sni_endpoint_id_or_sni_endpoint_name: unique identifier of this SNI endpoint or unique name for SNI endpoint
+    def info(app_id_or_app_name, sni_endpoint_id_or_sni_endpoint_name)
+      @client.sni_endpoint.info(app_id_or_app_name, sni_endpoint_id_or_sni_endpoint_name)
+    end
+
+    # List existing SNI endpoints.
+    #
+    # @param app_id_or_app_name: unique identifier of app or unique name of app
+    def list(app_id_or_app_name)
+      @client.sni_endpoint.list(app_id_or_app_name)
+    end
+
+    # Update an existing SNI endpoint.
+    #
+    # @param app_id_or_app_name: unique identifier of app or unique name of app
+    # @param sni_endpoint_id_or_sni_endpoint_name: unique identifier of this SNI endpoint or unique name for SNI endpoint
+    # @param body: the object to pass as the request payload
+    def update(app_id_or_app_name, sni_endpoint_id_or_sni_endpoint_name, body = {})
+      @client.sni_endpoint.update(app_id_or_app_name, sni_endpoint_id_or_sni_endpoint_name, body)
+    end
+  end
+
   # A source is a location for uploading and downloading an application's source code.
   class Source
     def initialize(client)
       @client = client
     end
 
+    # Create URLs for uploading and downloading source.
+    def create()
+      @client.source.create()
+    end
+
     # Create URLs for uploading and downloading source. Deprecated in favor of `POST /sources`
     #
     # @param app_id_or_app_name: unique identifier of app or unique name of app
-    def create(app_id_or_app_name)
-      @client.source.create(app_id_or_app_name)
+    def create_deprecated(app_id_or_app_name)
+      @client.source.create_deprecated(app_id_or_app_name)
     end
   end
 
@@ -2314,7 +2465,7 @@ module PlatformAPI
     end
   end
 
-  # [SSL Endpoint](https://devcenter.heroku.com/articles/ssl-endpoint) is a public address serving custom SSL cert for HTTPS traffic to a Heroku app. Note that an app must have the `ssl:endpoint` addon installed before it can provision an SSL Endpoint using these APIs.
+  # [SSL Endpoint](https://devcenter.heroku.com/articles/ssl-endpoint) is a public address serving custom SSL cert for HTTPS traffic to a Heroku app. Note that an app must have the `ssl:endpoint` add-on installed before it can provision an SSL Endpoint using these APIs.
   class SSLEndpoint
     def initialize(client)
       @client = client
@@ -2403,7 +2554,7 @@ module PlatformAPI
   end
 
   # Entities that have been whitelisted to be used by an Organization
-  class WhitelistedAddonService
+  class WhitelistedAddOnService
     def initialize(client)
       @client = client
     end
@@ -2412,7 +2563,7 @@ module PlatformAPI
     #
     # @param organization_name_or_organization_id: unique name of organization or unique identifier of organization
     def list(organization_name_or_organization_id)
-      @client.whitelisted_addon_service.list(organization_name_or_organization_id)
+      @client.whitelisted_add_on_service.list(organization_name_or_organization_id)
     end
 
     # Whitelist an Add-on Service
@@ -2420,62 +2571,15 @@ module PlatformAPI
     # @param organization_name_or_organization_id: unique name of organization or unique identifier of organization
     # @param body: the object to pass as the request payload
     def create(organization_name_or_organization_id, body = {})
-      @client.whitelisted_addon_service.create(organization_name_or_organization_id, body)
+      @client.whitelisted_add_on_service.create(organization_name_or_organization_id, body)
     end
 
     # Remove a whitelisted entity
     #
     # @param organization_name_or_organization_id: unique name of organization or unique identifier of organization
-    # @param whitelisted_addon_service_id_or_addon_service_name: unique identifier for this whitelisting entity or unique name of this addon-service
-    def delete(organization_name_or_organization_id, whitelisted_addon_service_id_or_addon_service_name)
-      @client.whitelisted_addon_service.delete(organization_name_or_organization_id, whitelisted_addon_service_id_or_addon_service_name)
-    end
-  end
-
-  # SNI Endpoint is a public address serving a custom SSL cert for HTTPS traffic, using the SNI TLS extension, to a Heroku app. Note: only apps with the `http-sni` and `stable-cname` feature flags or those owned by a user with the `user-http-sni` and `user-stable-cname` feature flags are authorized to use this endpoint.
-  class SniEndpoint
-    def initialize(client)
-      @client = client
-    end
-
-    # Create a new SNI endpoint.
-    #
-    # @param app_id_or_app_name: unique identifier of app or unique name of app
-    # @param body: the object to pass as the request payload
-    def create(app_id_or_app_name, body = {})
-      @client.sni_endpoint.create(app_id_or_app_name, body)
-    end
-
-    # Delete existing SNI endpoint.
-    #
-    # @param app_id_or_app_name: unique identifier of app or unique name of app
-    # @param sni_endpoint_id_or_sni_endpoint_name: unique identifier of this SNI endpoint or unique name for SNI endpoint
-    def delete(app_id_or_app_name, sni_endpoint_id_or_sni_endpoint_name)
-      @client.sni_endpoint.delete(app_id_or_app_name, sni_endpoint_id_or_sni_endpoint_name)
-    end
-
-    # Info for existing SNI endpoint.
-    #
-    # @param app_id_or_app_name: unique identifier of app or unique name of app
-    # @param sni_endpoint_id_or_sni_endpoint_name: unique identifier of this SNI endpoint or unique name for SNI endpoint
-    def info(app_id_or_app_name, sni_endpoint_id_or_sni_endpoint_name)
-      @client.sni_endpoint.info(app_id_or_app_name, sni_endpoint_id_or_sni_endpoint_name)
-    end
-
-    # List existing SNI endpoints.
-    #
-    # @param app_id_or_app_name: unique identifier of app or unique name of app
-    def list(app_id_or_app_name)
-      @client.sni_endpoint.list(app_id_or_app_name)
-    end
-
-    # Update an existing SNI endpoint.
-    #
-    # @param app_id_or_app_name: unique identifier of app or unique name of app
-    # @param sni_endpoint_id_or_sni_endpoint_name: unique identifier of this SNI endpoint or unique name for SNI endpoint
-    # @param body: the object to pass as the request payload
-    def update(app_id_or_app_name, sni_endpoint_id_or_sni_endpoint_name, body = {})
-      @client.sni_endpoint.update(app_id_or_app_name, sni_endpoint_id_or_sni_endpoint_name, body)
+    # @param whitelisted_add_on_service_id_or_add_on_service_name: unique identifier for this whitelisting entity or unique name of this add-on-service
+    def delete(organization_name_or_organization_id, whitelisted_add_on_service_id_or_add_on_service_name)
+      @client.whitelisted_add_on_service.delete(organization_name_or_organization_id, whitelisted_add_on_service_id_or_add_on_service_name)
     end
   end
 
@@ -2697,6 +2801,14 @@ module PlatformAPI
             "string"
           ]
         },
+        "federated": {
+          "description": "whether the user is federated and belongs to an Identity Provider",
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
         "id": {
           "description": "unique identifier of an account",
           "example": "01234567-89ab-cdef-0123-456789abcdef",
@@ -2736,14 +2848,6 @@ module PlatformAPI
           "type": [
             "string",
             "null"
-          ]
-        },
-        "new_password": {
-          "description": "the new password for the account when changing the password",
-          "example": "newpassword",
-          "readOnly": true,
-          "type": [
-            "string"
           ]
         },
         "password": {
@@ -2847,9 +2951,6 @@ module PlatformAPI
               },
               "name": {
                 "$ref": "#/definitions/account/definitions/name"
-              },
-              "password": {
-                "$ref": "#/definitions/account/definitions/password"
               }
             },
             "type": [
@@ -2860,57 +2961,6 @@ module PlatformAPI
             "$ref": "#/definitions/account"
           },
           "title": "Update"
-        },
-        {
-          "description": "Change Email for account.",
-          "href": "/account",
-          "method": "PATCH",
-          "rel": "update",
-          "schema": {
-            "properties": {
-              "email": {
-                "$ref": "#/definitions/account/definitions/email"
-              },
-              "password": {
-                "$ref": "#/definitions/account/definitions/password"
-              }
-            },
-            "required": [
-              "password",
-              "email"
-            ],
-            "type": [
-              "object"
-            ]
-          },
-          "title": "Change Email"
-        },
-        {
-          "description": "Change Password for account.",
-          "href": "/account",
-          "method": "PATCH",
-          "rel": "update",
-          "schema": {
-            "properties": {
-              "new_password": {
-                "$ref": "#/definitions/account/definitions/new_password"
-              },
-              "password": {
-                "$ref": "#/definitions/account/definitions/password"
-              }
-            },
-            "required": [
-              "new_password",
-              "password"
-            ],
-            "type": [
-              "object"
-            ]
-          },
-          "targetSchema": {
-            "$ref": "#/definitions/account"
-          },
-          "title": "Change Password"
         },
         {
           "description": "Delete account. Note that this action cannot be undone.",
@@ -2947,9 +2997,6 @@ module PlatformAPI
               },
               "name": {
                 "$ref": "#/definitions/account/definitions/name"
-              },
-              "password": {
-                "$ref": "#/definitions/account/definitions/password"
               }
             },
             "type": [
@@ -2960,57 +3007,6 @@ module PlatformAPI
             "$ref": "#/definitions/account"
           },
           "title": "Update"
-        },
-        {
-          "description": "Change Email for account.",
-          "href": "/users/{(%23%2Fdefinitions%2Faccount%2Fdefinitions%2Fidentity)}",
-          "method": "PATCH",
-          "rel": "update",
-          "schema": {
-            "properties": {
-              "email": {
-                "$ref": "#/definitions/account/definitions/email"
-              },
-              "password": {
-                "$ref": "#/definitions/account/definitions/password"
-              }
-            },
-            "required": [
-              "password",
-              "email"
-            ],
-            "type": [
-              "object"
-            ]
-          },
-          "title": "Change Email"
-        },
-        {
-          "description": "Change Password for account.",
-          "href": "/users/{(%23%2Fdefinitions%2Faccount%2Fdefinitions%2Fidentity)}",
-          "method": "PATCH",
-          "rel": "update",
-          "schema": {
-            "properties": {
-              "new_password": {
-                "$ref": "#/definitions/account/definitions/new_password"
-              },
-              "password": {
-                "$ref": "#/definitions/account/definitions/password"
-              }
-            },
-            "required": [
-              "new_password",
-              "password"
-            ],
-            "type": [
-              "object"
-            ]
-          },
-          "targetSchema": {
-            "$ref": "#/definitions/account"
-          },
-          "title": "Change Password"
         },
         {
           "description": "Delete account. Note that this action cannot be undone.",
@@ -3036,8 +3032,33 @@ module PlatformAPI
         "email": {
           "$ref": "#/definitions/account/definitions/email"
         },
+        "federated": {
+          "$ref": "#/definitions/account/definitions/federated"
+        },
         "id": {
           "$ref": "#/definitions/account/definitions/id"
+        },
+        "identity_provider": {
+          "description": "Identity Provider details for federated users.",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/identity-provider/definitions/id"
+            },
+            "organization": {
+              "type": [
+                "object"
+              ],
+              "properties": {
+                "name": {
+                  "$ref": "#/definitions/organization/definitions/name"
+                }
+              }
+            }
+          },
+          "type": [
+            "object",
+            "null"
+          ]
         },
         "last_login": {
           "$ref": "#/definitions/account/definitions/last_login"
@@ -3081,8 +3102,8 @@ module PlatformAPI
         }
       }
     },
-    "addon-action": {
-      "description": "Add-on Actions are Provider functionality for specific add-on installations",
+    "add-on-action": {
+      "description": "Add-on Actions are lifecycle operations for add-on provisioning and deprovisioning. They allow whitelisted add-on providers to (de)provision add-ons in the background and then report back when (de)provisioning is complete.",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "stability": "development",
       "strictProperties": true,
@@ -3091,70 +3112,33 @@ module PlatformAPI
         "object"
       ],
       "definitions": {
-        "id": {
-          "description": "a unique identifier",
-          "example": "01234567-89ab-cdef-0123-456789abcdef",
-          "format": "uuid",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "identity": {
-          "$ref": "#/definitions/addon-action/definitions/id"
-        },
-        "label": {
-          "description": "the display text shown in Dashboard",
-          "example": "Example",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "action": {
-          "description": "identifier of the action to take that is sent via SSO",
-          "example": "example",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "url": {
-          "description": "absolute URL to use instead of an action",
-          "example": "http://example.com?resource_id=:resource_id",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "requires_owner": {
-          "description": "if the action requires the user to own the app",
-          "example": true,
-          "readOnly": true,
-          "type": [
-            "boolean"
-          ]
-        }
       },
-      "properties": {
-        "id": {
-          "$ref": "#/definitions/addon-action/definitions/id"
+      "links": [
+        {
+          "description": "Mark an add-on as provisioned for use.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/actions/provision",
+          "method": "POST",
+          "rel": "create",
+          "targetSchema": {
+            "$ref": "#/definitions/add-on"
+          },
+          "title": "Create - Provision"
         },
-        "label": {
-          "$ref": "#/definitions/addon-action/definitions/label"
-        },
-        "action": {
-          "$ref": "#/definitions/addon-action/definitions/action"
-        },
-        "url": {
-          "$ref": "#/definitions/addon-action/definitions/url"
-        },
-        "requires_owner": {
-          "$ref": "#/definitions/addon-action/definitions/requires_owner"
+        {
+          "description": "Mark an add-on as deprovisioned.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/actions/deprovision",
+          "method": "POST",
+          "rel": "create",
+          "targetSchema": {
+            "$ref": "#/definitions/add-on"
+          },
+          "title": "Create - Deprovision"
         }
+      ],
+      "properties": {
       }
     },
-    "addon-attachment": {
+    "add-on-attachment": {
       "description": "An add-on attachment represents a connection between an app and an add-on that it has been given access to.",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "stability": "prototype",
@@ -3194,17 +3178,17 @@ module PlatformAPI
         "identity": {
           "anyOf": [
             {
-              "$ref": "#/definitions/addon-attachment/definitions/id"
+              "$ref": "#/definitions/add-on-attachment/definitions/id"
             }
           ]
         },
         "scopedIdentity": {
           "anyOf": [
             {
-              "$ref": "#/definitions/addon-attachment/definitions/id"
+              "$ref": "#/definitions/add-on-attachment/definitions/id"
             },
             {
-              "$ref": "#/definitions/addon-attachment/definitions/name"
+              "$ref": "#/definitions/add-on-attachment/definitions/name"
             }
           ]
         },
@@ -3245,16 +3229,16 @@ module PlatformAPI
           "schema": {
             "properties": {
               "addon": {
-                "$ref": "#/definitions/addon/definitions/identity"
+                "$ref": "#/definitions/add-on/definitions/identity"
               },
               "app": {
                 "$ref": "#/definitions/app/definitions/identity"
               },
               "force": {
-                "$ref": "#/definitions/addon-attachment/definitions/force"
+                "$ref": "#/definitions/add-on-attachment/definitions/force"
               },
               "name": {
-                "$ref": "#/definitions/addon-attachment/definitions/name"
+                "$ref": "#/definitions/add-on-attachment/definitions/name"
               }
             },
             "required": [
@@ -3266,27 +3250,27 @@ module PlatformAPI
             ]
           },
           "targetSchema": {
-            "$ref": "#/definitions/addon-attachment"
+            "$ref": "#/definitions/add-on-attachment"
           },
           "title": "Create"
         },
         {
           "description": "Delete an existing add-on attachment.",
-          "href": "/addon-attachments/{(%23%2Fdefinitions%2Faddon-attachment%2Fdefinitions%2Fidentity)}",
+          "href": "/addon-attachments/{(%23%2Fdefinitions%2Fadd-on-attachment%2Fdefinitions%2Fidentity)}",
           "method": "DELETE",
           "rel": "destroy",
           "targetSchema": {
-            "$ref": "#/definitions/addon-attachment"
+            "$ref": "#/definitions/add-on-attachment"
           },
           "title": "Delete"
         },
         {
           "description": "Info for existing add-on attachment.",
-          "href": "/addon-attachments/{(%23%2Fdefinitions%2Faddon-attachment%2Fdefinitions%2Fidentity)}",
+          "href": "/addon-attachments/{(%23%2Fdefinitions%2Fadd-on-attachment%2Fdefinitions%2Fidentity)}",
           "method": "GET",
           "rel": "self",
           "targetSchema": {
-            "$ref": "#/definitions/addon-attachment"
+            "$ref": "#/definitions/add-on-attachment"
           },
           "title": "Info"
         },
@@ -3297,7 +3281,7 @@ module PlatformAPI
           "rel": "instances",
           "targetSchema": {
             "items": {
-              "$ref": "#/definitions/addon-attachment"
+              "$ref": "#/definitions/add-on-attachment"
             },
             "type": [
               "array"
@@ -3307,12 +3291,12 @@ module PlatformAPI
         },
         {
           "description": "List existing add-on attachments for an add-on.",
-          "href": "/addons/{(%23%2Fdefinitions%2Faddon%2Fdefinitions%2Fidentity)}/addon-attachments",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/addon-attachments",
           "method": "GET",
           "rel": "instances",
           "targetSchema": {
             "items": {
-              "$ref": "#/definitions/addon-attachment"
+              "$ref": "#/definitions/add-on-attachment"
             },
             "type": [
               "array"
@@ -3327,7 +3311,7 @@ module PlatformAPI
           "rel": "instances",
           "targetSchema": {
             "items": {
-              "$ref": "#/definitions/addon-attachment"
+              "$ref": "#/definitions/add-on-attachment"
             },
             "type": [
               "array"
@@ -3337,11 +3321,11 @@ module PlatformAPI
         },
         {
           "description": "Info for existing add-on attachment for an app.",
-          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/addon-attachments/{(%23%2Fdefinitions%2Faddon-attachment%2Fdefinitions%2FscopedIdentity)}",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/addon-attachments/{(%23%2Fdefinitions%2Fadd-on-attachment%2Fdefinitions%2FscopedIdentity)}",
           "method": "GET",
           "rel": "self",
           "targetSchema": {
-            "$ref": "#/definitions/addon-attachment"
+            "$ref": "#/definitions/add-on-attachment"
           },
           "title": "Info by App"
         }
@@ -3351,10 +3335,10 @@ module PlatformAPI
           "description": "identity of add-on",
           "properties": {
             "id": {
-              "$ref": "#/definitions/addon/definitions/id"
+              "$ref": "#/definitions/add-on/definitions/id"
             },
             "name": {
-              "$ref": "#/definitions/addon/definitions/name"
+              "$ref": "#/definitions/add-on/definitions/name"
             },
             "app": {
               "description": "billing application associated with this add-on",
@@ -3413,23 +3397,23 @@ module PlatformAPI
           ]
         },
         "created_at": {
-          "$ref": "#/definitions/addon-attachment/definitions/created_at"
+          "$ref": "#/definitions/add-on-attachment/definitions/created_at"
         },
         "id": {
-          "$ref": "#/definitions/addon-attachment/definitions/id"
+          "$ref": "#/definitions/add-on-attachment/definitions/id"
         },
         "name": {
-          "$ref": "#/definitions/addon-attachment/definitions/name"
+          "$ref": "#/definitions/add-on-attachment/definitions/name"
         },
         "updated_at": {
-          "$ref": "#/definitions/addon-attachment/definitions/updated_at"
+          "$ref": "#/definitions/add-on-attachment/definitions/updated_at"
         },
         "web_url": {
-          "$ref": "#/definitions/addon-attachment/definitions/web_url"
+          "$ref": "#/definitions/add-on-attachment/definitions/web_url"
         }
       }
     },
-    "addon-config": {
+    "add-on-config": {
       "description": "Configuration of an Add-on",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "stability": "development",
@@ -3442,7 +3426,7 @@ module PlatformAPI
         "identity": {
           "anyOf": [
             {
-              "$ref": "#/definitions/addon-config/definitions/name"
+              "$ref": "#/definitions/add-on-config/definitions/name"
             }
           ]
         },
@@ -3464,13 +3448,13 @@ module PlatformAPI
       },
       "links": [
         {
-          "description": "Get an add-on's config",
-          "href": "/addons/{(%23%2Fdefinitions%2Faddon%2Fdefinitions%2Fidentity)}/config",
+          "description": "Get an add-on's config. Accessible by customers with access and by the add-on partner providing this add-on.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/config",
           "method": "GET",
           "rel": "instances",
           "targetSchema": {
             "items": {
-              "$ref": "#/definitions/addon-config"
+              "$ref": "#/definitions/add-on-config"
             },
             "type": [
               "array"
@@ -3479,15 +3463,15 @@ module PlatformAPI
           "title": "List"
         },
         {
-          "description": "Update an add-on's config.",
-          "href": "/addons/{(%23%2Fdefinitions%2Faddon%2Fdefinitions%2Fidentity)}/config",
+          "description": "Update an add-on's config. Can only be accessed by the add-on partner providing this add-on.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/config",
           "method": "PATCH",
           "rel": "update",
           "schema": {
             "properties": {
               "config": {
                 "items": {
-                  "$ref": "#/definitions/addon-config"
+                  "$ref": "#/definitions/add-on-config"
                 },
                 "type": [
                   "array"
@@ -3500,7 +3484,7 @@ module PlatformAPI
           },
           "targetSchema": {
             "items": {
-              "$ref": "#/definitions/addon-config"
+              "$ref": "#/definitions/add-on-config"
             }
           },
           "title": "Update"
@@ -3508,14 +3492,87 @@ module PlatformAPI
       ],
       "properties": {
         "name": {
-          "$ref": "#/definitions/addon-config/definitions/name"
+          "$ref": "#/definitions/add-on-config/definitions/name"
         },
         "value": {
-          "$ref": "#/definitions/addon-config/definitions/value"
+          "$ref": "#/definitions/add-on-config/definitions/value"
         }
       }
     },
-    "addon-region-capability": {
+    "add-on-plan-action": {
+      "description": "Add-on Plan Actions are Provider functionality for specific add-on installations",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "development",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Add-on Plan Action",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "id": {
+          "description": "a unique identifier",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "$ref": "#/definitions/add-on-plan-action/definitions/id"
+        },
+        "label": {
+          "description": "the display text shown in Dashboard",
+          "example": "Example",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "action": {
+          "description": "identifier of the action to take that is sent via SSO",
+          "example": "example",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "url": {
+          "description": "absolute URL to use instead of an action",
+          "example": "http://example.com?resource_id=:resource_id",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "requires_owner": {
+          "description": "if the action requires the user to own the app",
+          "example": true,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        }
+      },
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/add-on-plan-action/definitions/id"
+        },
+        "label": {
+          "$ref": "#/definitions/add-on-plan-action/definitions/label"
+        },
+        "action": {
+          "$ref": "#/definitions/add-on-plan-action/definitions/action"
+        },
+        "url": {
+          "$ref": "#/definitions/add-on-plan-action/definitions/url"
+        },
+        "requires_owner": {
+          "$ref": "#/definitions/add-on-plan-action/definitions/requires_owner"
+        }
+      }
+    },
+    "add-on-region-capability": {
       "description": "Add-on region capabilities represent the relationship between an Add-on Service and a specific Region. Only Beta and GA add-ons are returned by these endpoints.",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "stability": "production",
@@ -3526,7 +3583,7 @@ module PlatformAPI
       ],
       "definitions": {
         "id": {
-          "description": "unique identifier of this addon-region-capability",
+          "description": "unique identifier of this add-on-region-capability",
           "example": "01234567-89ab-cdef-0123-456789abcdef",
           "format": "uuid",
           "readOnly": true,
@@ -3542,7 +3599,7 @@ module PlatformAPI
           ]
         },
         "identity": {
-          "$ref": "#/definitions/addon-region-capability/definitions/id"
+          "$ref": "#/definitions/add-on-region-capability/definitions/id"
         }
       },
       "links": [
@@ -3553,7 +3610,7 @@ module PlatformAPI
           "rel": "instances",
           "targetSchema": {
             "items": {
-              "$ref": "#/definitions/addon-region-capability"
+              "$ref": "#/definitions/add-on-region-capability"
             },
             "type": [
               "array"
@@ -3562,13 +3619,13 @@ module PlatformAPI
           "title": "List"
         },
         {
-          "description": "List existing add-on region capabilities for an addon-service",
-          "href": "/addon-services/{(%23%2Fdefinitions%2Faddon-service%2Fdefinitions%2Fidentity)}/region-capabilities",
+          "description": "List existing add-on region capabilities for an add-on-service",
+          "href": "/addon-services/{(%23%2Fdefinitions%2Fadd-on-service%2Fdefinitions%2Fidentity)}/region-capabilities",
           "method": "GET",
           "rel": "instances",
           "targetSchema": {
             "items": {
-              "$ref": "#/definitions/addon-region-capability"
+              "$ref": "#/definitions/add-on-region-capability"
             },
             "type": [
               "array"
@@ -3583,7 +3640,7 @@ module PlatformAPI
           "rel": "instances",
           "targetSchema": {
             "items": {
-              "$ref": "#/definitions/addon-region-capability"
+              "$ref": "#/definitions/add-on-region-capability"
             },
             "type": [
               "array"
@@ -3594,20 +3651,20 @@ module PlatformAPI
       ],
       "properties": {
         "id": {
-          "$ref": "#/definitions/addon-region-capability/definitions/id"
+          "$ref": "#/definitions/add-on-region-capability/definitions/id"
         },
         "supports_private_networking": {
-          "$ref": "#/definitions/addon-region-capability/definitions/supports_private_networking"
+          "$ref": "#/definitions/add-on-region-capability/definitions/supports_private_networking"
         },
         "addon_service": {
-          "$ref": "#/definitions/addon-service"
+          "$ref": "#/definitions/add-on-service"
         },
         "region": {
           "$ref": "#/definitions/region"
         }
       }
     },
-    "addon-service": {
+    "add-on-service": {
       "description": "Add-on services represent add-ons that may be provisioned for apps. Endpoints under add-on services can be accessed without authentication.",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "stability": "production",
@@ -3627,7 +3684,7 @@ module PlatformAPI
           ]
         },
         "created_at": {
-          "description": "when addon-service was created",
+          "description": "when add-on-service was created",
           "example": "2012-01-01T12:00:00Z",
           "format": "date-time",
           "readOnly": true,
@@ -3636,7 +3693,7 @@ module PlatformAPI
           ]
         },
         "human_name": {
-          "description": "human-readable name of the addon service provider",
+          "description": "human-readable name of the add-on service provider",
           "example": "Heroku Postgres",
           "readOnly": true,
           "type": [
@@ -3644,7 +3701,7 @@ module PlatformAPI
           ]
         },
         "id": {
-          "description": "unique identifier of this addon-service",
+          "description": "unique identifier of this add-on-service",
           "example": "01234567-89ab-cdef-0123-456789abcdef",
           "format": "uuid",
           "readOnly": true,
@@ -3655,15 +3712,15 @@ module PlatformAPI
         "identity": {
           "anyOf": [
             {
-              "$ref": "#/definitions/addon-service/definitions/id"
+              "$ref": "#/definitions/add-on-service/definitions/id"
             },
             {
-              "$ref": "#/definitions/addon-service/definitions/name"
+              "$ref": "#/definitions/add-on-service/definitions/name"
             }
           ]
         },
         "name": {
-          "description": "unique name of this addon-service",
+          "description": "unique name of this add-on-service",
           "example": "heroku-postgresql",
           "readOnly": true,
           "type": [
@@ -3703,7 +3760,7 @@ module PlatformAPI
           ]
         },
         "updated_at": {
-          "description": "when addon-service was updated",
+          "description": "when add-on-service was updated",
           "example": "2012-01-01T12:00:00Z",
           "format": "date-time",
           "readOnly": true,
@@ -3714,23 +3771,23 @@ module PlatformAPI
       },
       "links": [
         {
-          "description": "Info for existing addon-service.",
-          "href": "/addon-services/{(%23%2Fdefinitions%2Faddon-service%2Fdefinitions%2Fidentity)}",
+          "description": "Info for existing add-on-service.",
+          "href": "/addon-services/{(%23%2Fdefinitions%2Fadd-on-service%2Fdefinitions%2Fidentity)}",
           "method": "GET",
           "rel": "self",
           "targetSchema": {
-            "$ref": "#/definitions/addon-service"
+            "$ref": "#/definitions/add-on-service"
           },
           "title": "Info"
         },
         {
-          "description": "List existing addon-services.",
+          "description": "List existing add-on-services.",
           "href": "/addon-services",
           "method": "GET",
           "rel": "instances",
           "targetSchema": {
             "items": {
-              "$ref": "#/definitions/addon-service"
+              "$ref": "#/definitions/add-on-service"
             },
             "type": [
               "array"
@@ -3741,35 +3798,35 @@ module PlatformAPI
       ],
       "properties": {
         "cli_plugin_name": {
-          "$ref": "#/definitions/addon-service/definitions/cli_plugin_name"
+          "$ref": "#/definitions/add-on-service/definitions/cli_plugin_name"
         },
         "created_at": {
-          "$ref": "#/definitions/addon-service/definitions/created_at"
+          "$ref": "#/definitions/add-on-service/definitions/created_at"
         },
         "human_name": {
-          "$ref": "#/definitions/addon-service/definitions/human_name"
+          "$ref": "#/definitions/add-on-service/definitions/human_name"
         },
         "id": {
-          "$ref": "#/definitions/addon-service/definitions/id"
+          "$ref": "#/definitions/add-on-service/definitions/id"
         },
         "name": {
-          "$ref": "#/definitions/addon-service/definitions/name"
+          "$ref": "#/definitions/add-on-service/definitions/name"
         },
         "state": {
-          "$ref": "#/definitions/addon-service/definitions/state"
+          "$ref": "#/definitions/add-on-service/definitions/state"
         },
         "supports_multiple_installations": {
-          "$ref": "#/definitions/addon-service/definitions/supports_multiple_installations"
+          "$ref": "#/definitions/add-on-service/definitions/supports_multiple_installations"
         },
         "supports_sharing": {
-          "$ref": "#/definitions/addon-service/definitions/supports_sharing"
+          "$ref": "#/definitions/add-on-service/definitions/supports_sharing"
         },
         "updated_at": {
-          "$ref": "#/definitions/addon-service/definitions/updated_at"
+          "$ref": "#/definitions/add-on-service/definitions/updated_at"
         }
       }
     },
-    "addon": {
+    "add-on": {
       "description": "Add-ons represent add-ons that have been provisioned and attached to one or more apps.",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "stability": "production",
@@ -3792,19 +3849,19 @@ module PlatformAPI
           "readOnly": true,
           "properties": {
             "id": {
-              "$ref": "#/definitions/addon-action/definitions/id"
+              "$ref": "#/definitions/add-on-plan-action/definitions/id"
             },
             "label": {
-              "$ref": "#/definitions/addon-action/definitions/label"
+              "$ref": "#/definitions/add-on-plan-action/definitions/label"
             },
             "action": {
-              "$ref": "#/definitions/addon-action/definitions/action"
+              "$ref": "#/definitions/add-on-plan-action/definitions/action"
             },
             "url": {
-              "$ref": "#/definitions/addon-action/definitions/url"
+              "$ref": "#/definitions/add-on-plan-action/definitions/url"
             },
             "requires_owner": {
-              "$ref": "#/definitions/addon-action/definitions/requires_owner"
+              "$ref": "#/definitions/add-on-plan-action/definitions/requires_owner"
             }
           }
         },
@@ -3845,10 +3902,10 @@ module PlatformAPI
         "identity": {
           "anyOf": [
             {
-              "$ref": "#/definitions/addon/definitions/id"
+              "$ref": "#/definitions/add-on/definitions/id"
             },
             {
-              "$ref": "#/definitions/addon/definitions/name"
+              "$ref": "#/definitions/add-on/definitions/name"
             }
           ]
         },
@@ -3864,6 +3921,19 @@ module PlatformAPI
         "provider_id": {
           "description": "id of this add-on with its provider",
           "example": "abcd1234",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "state": {
+          "description": "state in the add-on's lifecycle",
+          "enum": [
+            "provisioning",
+            "provisioned",
+            "deprovisioned"
+          ],
+          "example": "provisioned",
           "readOnly": true,
           "type": [
             "string"
@@ -3903,7 +3973,7 @@ module PlatformAPI
                   "name": "DATABASE_FOLLOWER"
                 },
                 "name": {
-                  "$ref": "#/definitions/addon-attachment/definitions/name"
+                  "$ref": "#/definitions/add-on-attachment/definitions/name"
                 },
                 "type": [
                   "object"
@@ -3938,27 +4008,27 @@ module PlatformAPI
             ]
           },
           "targetSchema": {
-            "$ref": "#/definitions/addon"
+            "$ref": "#/definitions/add-on"
           },
           "title": "Create"
         },
         {
           "description": "Delete an existing add-on.",
-          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/addons/{(%23%2Fdefinitions%2Faddon%2Fdefinitions%2Fidentity)}",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}",
           "method": "DELETE",
           "rel": "destroy",
           "targetSchema": {
-            "$ref": "#/definitions/addon"
+            "$ref": "#/definitions/add-on"
           },
           "title": "Delete"
         },
         {
           "description": "Info for an existing add-on.",
-          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/addons/{(%23%2Fdefinitions%2Faddon%2Fdefinitions%2Fidentity)}",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}",
           "method": "GET",
           "rel": "self",
           "targetSchema": {
-            "$ref": "#/definitions/addon"
+            "$ref": "#/definitions/add-on"
           },
           "title": "Info"
         },
@@ -3969,7 +4039,7 @@ module PlatformAPI
           "rel": "instances",
           "targetSchema": {
             "items": {
-              "$ref": "#/definitions/addon"
+              "$ref": "#/definitions/add-on"
             },
             "type": [
               "array"
@@ -3979,11 +4049,11 @@ module PlatformAPI
         },
         {
           "description": "Info for an existing add-on.",
-          "href": "/addons/{(%23%2Fdefinitions%2Faddon%2Fdefinitions%2Fidentity)}",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}",
           "method": "GET",
           "rel": "self",
           "targetSchema": {
-            "$ref": "#/definitions/addon"
+            "$ref": "#/definitions/add-on"
           },
           "title": "Info"
         },
@@ -3994,7 +4064,7 @@ module PlatformAPI
           "rel": "instances",
           "targetSchema": {
             "items": {
-              "$ref": "#/definitions/addon"
+              "$ref": "#/definitions/add-on"
             },
             "type": [
               "array"
@@ -4009,7 +4079,7 @@ module PlatformAPI
           "rel": "instances",
           "targetSchema": {
             "items": {
-              "$ref": "#/definitions/addon"
+              "$ref": "#/definitions/add-on"
             },
             "type": [
               "array"
@@ -4019,7 +4089,7 @@ module PlatformAPI
         },
         {
           "description": "Change add-on plan. Some add-ons may not support changing plans. In that case, an error will be returned.",
-          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/addons/{(%23%2Fdefinitions%2Faddon%2Fdefinitions%2Fidentity)}",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}",
           "method": "PATCH",
           "rel": "update",
           "schema": {
@@ -4040,16 +4110,16 @@ module PlatformAPI
       ],
       "properties": {
         "actions": {
-          "$ref": "#/definitions/addon/definitions/actions"
+          "$ref": "#/definitions/add-on/definitions/actions"
         },
         "addon_service": {
           "description": "identity of add-on service",
           "properties": {
             "id": {
-              "$ref": "#/definitions/addon-service/definitions/id"
+              "$ref": "#/definitions/add-on-service/definitions/id"
             },
             "name": {
-              "$ref": "#/definitions/addon-service/definitions/name"
+              "$ref": "#/definitions/add-on-service/definitions/name"
             }
           },
           "strictProperties": true,
@@ -4073,16 +4143,16 @@ module PlatformAPI
           "strictProperties": true
         },
         "config_vars": {
-          "$ref": "#/definitions/addon/definitions/config_vars"
+          "$ref": "#/definitions/add-on/definitions/config_vars"
         },
         "created_at": {
-          "$ref": "#/definitions/addon/definitions/created_at"
+          "$ref": "#/definitions/add-on/definitions/created_at"
         },
         "id": {
-          "$ref": "#/definitions/addon/definitions/id"
+          "$ref": "#/definitions/add-on/definitions/id"
         },
         "name": {
-          "$ref": "#/definitions/addon/definitions/name"
+          "$ref": "#/definitions/add-on/definitions/name"
         },
         "plan": {
           "description": "identity of add-on plan",
@@ -4100,13 +4170,16 @@ module PlatformAPI
           ]
         },
         "provider_id": {
-          "$ref": "#/definitions/addon/definitions/provider_id"
+          "$ref": "#/definitions/add-on/definitions/provider_id"
+        },
+        "state": {
+          "$ref": "#/definitions/add-on/definitions/state"
         },
         "updated_at": {
-          "$ref": "#/definitions/addon/definitions/updated_at"
+          "$ref": "#/definitions/add-on/definitions/updated_at"
         },
         "web_url": {
-          "$ref": "#/definitions/addon/definitions/web_url"
+          "$ref": "#/definitions/add-on/definitions/web_url"
         }
       }
     },
@@ -4275,6 +4348,64 @@ module PlatformAPI
         }
       }
     },
+    "app-formation-set": {
+      "description": "App formation set describes the combination of process types with their quantities and sizes as well as application process tier",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "development",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Application Formation Set",
+      "type": [
+        "object"
+      ],
+      "properties": {
+        "description": {
+          "description": "a string representation of the formation set",
+          "example": "web@2:Standard-2X worker@3:Performance-M",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "process_tier": {
+          "description": "application process tier",
+          "enum": [
+            "production",
+            "traditional",
+            "free",
+            "hobby",
+            "private"
+          ],
+          "example": "production",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "app": {
+          "description": "app being described by the formation-set",
+          "properties": {
+            "name": {
+              "$ref": "#/definitions/app/definitions/name"
+            },
+            "id": {
+              "$ref": "#/definitions/app/definitions/id"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "updated_at": {
+          "description": "last time fomation-set was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      }
+    },
     "app-setup": {
       "description": "An app setup represents an app on Heroku that is setup using an environment, addons, and scripts described in an app.json manifest file.",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
@@ -4299,6 +4430,21 @@ module PlatformAPI
             {
               "$ref": "#/definitions/app-setup/definitions/id"
             }
+          ]
+        },
+        "buildpack_override": {
+          "description": "a buildpack override",
+          "properties": {
+            "url": {
+              "description": "location of the buildpack",
+              "example": "https://example.com/buildpack.tgz",
+              "type": [
+                "string"
+              ]
+            }
+          },
+          "type": [
+            "object"
           ]
         },
         "created_at": {
@@ -4363,6 +4509,58 @@ module PlatformAPI
           },
           "type": [
             "array"
+          ]
+        },
+        "overrides": {
+          "description": "overrides of keys in the app.json manifest file",
+          "example": {
+            "buildpacks": [
+              {
+                "url": "https://example.com/buildpack.tgz"
+              }
+            ],
+            "env": {
+              "FOO": "bar",
+              "BAZ": "qux"
+            }
+          },
+          "properties": {
+            "buildpacks": {
+              "description": "overrides the buildpacks specified in the app.json manifest file",
+              "example": [
+                {
+                  "url": "https://example.com/buildpack.tgz"
+                }
+              ],
+              "items": {
+                "$ref": "#/definitions/app-setup/definitions/buildpack_override"
+              },
+              "type": [
+                "array"
+              ]
+            },
+            "env": {
+              "description": "overrides of the env specified in the app.json manifest file",
+              "example": {
+                "FOO": "bar",
+                "BAZ": "qux"
+              },
+              "readOnly": true,
+              "additionalProperties": false,
+              "patternProperties": {
+                "^\\w+$": {
+                  "type": [
+                    "string"
+                  ]
+                }
+              },
+              "type": [
+                "object"
+              ]
+            }
+          },
+          "type": [
+            "object"
           ]
         },
         "postdeploy": {
@@ -4485,6 +4683,9 @@ module PlatformAPI
                   "region": {
                     "$ref": "#/definitions/region/definitions/name"
                   },
+                  "space": {
+                    "$ref": "#/definitions/space/definitions/name"
+                  },
                   "stack": {
                     "$ref": "#/definitions/stack/definitions/name"
                   }
@@ -4528,37 +4729,7 @@ module PlatformAPI
                 ]
               },
               "overrides": {
-                "description": "overrides of keys in the app.json manifest file",
-                "example": {
-                  "env": {
-                    "FOO": "bar",
-                    "BAZ": "qux"
-                  }
-                },
-                "properties": {
-                  "env": {
-                    "description": "overrides of the env specified in the app.json manifest file",
-                    "example": {
-                      "FOO": "bar",
-                      "BAZ": "qux"
-                    },
-                    "readOnly": true,
-                    "additionalProperties": false,
-                    "patternProperties": {
-                      "^\\w+$": {
-                        "type": [
-                          "string"
-                        ]
-                      }
-                    },
-                    "type": [
-                      "object"
-                    ]
-                  }
-                },
-                "type": [
-                  "object"
-                ]
+                "$ref": "#/definitions/app-setup/definitions/overrides"
               }
             }
           },
@@ -4930,6 +5101,15 @@ module PlatformAPI
           "type": [
             "string"
           ]
+        },
+        "acm": {
+          "description": "ACM status of this app",
+          "default": false,
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
         }
       },
       "links": [
@@ -5145,6 +5325,9 @@ module PlatformAPI
             },
             "name": {
               "$ref": "#/definitions/space/definitions/name"
+            },
+            "shield": {
+              "$ref": "#/definitions/space/definitions/shield"
             }
           },
           "type": [
@@ -5858,6 +6041,9 @@ module PlatformAPI
             "email": {
               "$ref": "#/definitions/account/definitions/email"
             },
+            "federated": {
+              "$ref": "#/definitions/account/definitions/federated"
+            },
             "id": {
               "$ref": "#/definitions/account/definitions/id"
             }
@@ -5908,7 +6094,17 @@ module PlatformAPI
           "targetSchema": {
             "$ref": "#/definitions/config-var/definitions/config_vars"
           },
-          "title": "Info"
+          "title": "Info for App"
+        },
+        {
+          "description": "Get config-vars for a release.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/releases/{(%23%2Fdefinitions%2Frelease%2Fdefinitions%2Fidentity)}/config-vars",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/config-var/definitions/config_vars"
+          },
+          "title": "Info for App Release"
         },
         {
           "description": "Update config-vars for app. You can update existing config-vars by setting them again, and remove by setting it to `null`.",
@@ -6289,6 +6485,164 @@ module PlatformAPI
         }
       }
     },
+    "dyno-size": {
+      "description": "Dyno sizes are the values and details of sizes that can be assigned to dynos. This information can also be found at : [https://devcenter.heroku.com/articles/dyno-types](https://devcenter.heroku.com/articles/dyno-types).",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "prototype",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Dyno Size",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "compute": {
+          "description": "minimum vCPUs, non-dedicated may get more depending on load",
+          "example": 1,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "dedicated": {
+          "description": "whether this dyno will be dedicated to one user",
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of this dyno size",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/dyno-size/definitions/id"
+            },
+            {
+              "$ref": "#/definitions/dyno-size/definitions/name"
+            }
+          ]
+        },
+        "memory": {
+          "description": "amount of RAM in GB",
+          "example": 0.5,
+          "readOnly": true,
+          "type": [
+            "number"
+          ]
+        },
+        "name": {
+          "description": "the name of this dyno-size",
+          "example": "free",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "cost": {
+          "description": "price information for this dyno size",
+          "readOnly": true,
+          "type": [
+            "null",
+            "object"
+          ],
+          "definitions": {
+            "cents": {
+              "description": "price in cents per unit time",
+              "example": 0,
+              "readOnly": true,
+              "type": [
+                "integer"
+              ]
+            },
+            "unit": {
+              "description": "unit of price for dyno",
+              "readOnly": true,
+              "example": "month",
+              "type": [
+                "string"
+              ]
+            }
+          }
+        },
+        "dyno_units": {
+          "description": "unit of consumption for Heroku Enterprise customers",
+          "example": 0,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "private_space_only": {
+          "description": "whether this dyno can only be provisioned in a private space",
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Info for existing dyno size.",
+          "href": "/dyno-sizes/{(%23%2Fdefinitions%2Fdyno-size%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/dyno-size"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List existing dyno sizes.",
+          "href": "/dyno-sizes",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/dyno-size"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "compute": {
+          "$ref": "#/definitions/dyno-size/definitions/compute"
+        },
+        "cost": {
+          "$ref": "#/definitions/dyno-size/definitions/cost"
+        },
+        "dedicated": {
+          "$ref": "#/definitions/dyno-size/definitions/dedicated"
+        },
+        "dyno_units": {
+          "$ref": "#/definitions/dyno-size/definitions/dyno_units"
+        },
+        "id": {
+          "$ref": "#/definitions/dyno-size/definitions/id"
+        },
+        "memory": {
+          "$ref": "#/definitions/dyno-size/definitions/memory"
+        },
+        "name": {
+          "$ref": "#/definitions/dyno-size/definitions/name"
+        },
+        "private_space_only": {
+          "$ref": "#/definitions/dyno-size/definitions/private_space_only"
+        }
+      }
+    },
     "dyno": {
       "description": "Dynos encapsulate running processes of an app on Heroku. Detailed information about dyno sizes can be found at: [https://devcenter.heroku.com/articles/dyno-types](https://devcenter.heroku.com/articles/dyno-types).",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
@@ -6487,7 +6841,7 @@ module PlatformAPI
           "title": "Restart"
         },
         {
-          "description": "Restart all dynos",
+          "description": "Restart all dynos.",
           "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/dynos",
           "method": "DELETE",
           "rel": "empty",
@@ -6498,6 +6852,19 @@ module PlatformAPI
             ]
           },
           "title": "Restart all"
+        },
+        {
+          "description": "Stop dyno.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/dynos/{(%23%2Fdefinitions%2Fdyno%2Fdefinitions%2Fidentity)}/actions/stop",
+          "method": "POST",
+          "rel": "empty",
+          "targetSchema": {
+            "additionalPoperties": false,
+            "type": [
+              "object"
+            ]
+          },
+          "title": "Stop"
         },
         {
           "description": "Info for existing dyno.",
@@ -6625,13 +6992,16 @@ module PlatformAPI
               "$ref": "#/definitions/account"
             },
             {
-              "$ref": "#/definitions/addon"
+              "$ref": "#/definitions/add-on"
             },
             {
-              "$ref": "#/definitions/addon-attachment"
+              "$ref": "#/definitions/add-on-attachment"
             },
             {
               "$ref": "#/definitions/app"
+            },
+            {
+              "$ref": "#/definitions/app-formation-set"
             },
             {
               "$ref": "#/definitions/app-setup"
@@ -6656,6 +7026,9 @@ module PlatformAPI
             },
             {
               "$ref": "#/definitions/formation"
+            },
+            {
+              "$ref": "#/definitions/inbound-ruleset"
             },
             {
               "$ref": "#/definitions/organization"
@@ -6712,6 +7085,8 @@ module PlatformAPI
             "dyno",
             "failed-event",
             "formation",
+            "formation-set",
+            "inbound-ruleset",
             "organization",
             "release",
             "space",
@@ -7067,6 +7442,7 @@ module PlatformAPI
           "description": "type of process to maintain",
           "example": "web",
           "readOnly": true,
+          "pattern": "^[-\\w]{1,128}$",
           "type": [
             "string"
           ]
@@ -7225,6 +7601,202 @@ module PlatformAPI
         },
         "updated_at": {
           "$ref": "#/definitions/formation/definitions/updated_at"
+        }
+      }
+    },
+    "identity-provider": {
+      "description": "Identity Providers represent the SAML configuration of an Organization.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Identity Provider",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "certificate": {
+          "description": "raw contents of the public certificate (eg: .crt or .pem file)",
+          "example": "-----BEGIN CERTIFICATE----- ...",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "created_at": {
+          "description": "when provider record was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "entity_id": {
+          "description": "URL identifier provided by the identity provider",
+          "example": "https://customer-domain.idp.com",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of this identity provider",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "slo_target_url": {
+          "description": "single log out URL for this identity provider",
+          "example": "https://example.com/idp/logout",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "sso_target_url": {
+          "description": "single sign on URL for this identity provider",
+          "example": "https://example.com/idp/login",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when the identity provider record was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Get a list of an organization's Identity Providers",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fname)}/identity-providers",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/identity-provider"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "Create an Identity Provider for an organization",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fname)}/identity-providers",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "certificate": {
+                "$ref": "#/definitions/identity-provider/definitions/certificate"
+              },
+              "entity_id": {
+                "$ref": "#/definitions/identity-provider/definitions/entity_id"
+              },
+              "slo_target_url": {
+                "$ref": "#/definitions/identity-provider/definitions/slo_target_url"
+              },
+              "sso_target_url": {
+                "$ref": "#/definitions/identity-provider/definitions/sso_target_url"
+              }
+            },
+            "required": [
+              "certificate",
+              "sso_target_url",
+              "entity_id"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/identity-provider"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Update an organization's Identity Provider",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fname)}/identity-providers/{(%23%2Fdefinitions%2Fidentity-provider%2Fdefinitions%2Fid)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "certificate": {
+                "$ref": "#/definitions/identity-provider/definitions/certificate"
+              },
+              "entity_id": {
+                "$ref": "#/definitions/identity-provider/definitions/entity_id"
+              },
+              "slo_target_url": {
+                "$ref": "#/definitions/identity-provider/definitions/slo_target_url"
+              },
+              "sso_target_url": {
+                "$ref": "#/definitions/identity-provider/definitions/sso_target_url"
+              }
+            },
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/identity-provider"
+          },
+          "title": "Update"
+        },
+        {
+          "description": "Delete an organization's Identity Provider",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fname)}/identity-providers/{(%23%2Fdefinitions%2Fidentity-provider%2Fdefinitions%2Fid)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/identity-provider"
+          },
+          "title": "Delete"
+        }
+      ],
+      "properties": {
+        "certificate": {
+          "$ref": "#/definitions/identity-provider/definitions/certificate"
+        },
+        "created_at": {
+          "$ref": "#/definitions/identity-provider/definitions/created_at"
+        },
+        "entity_id": {
+          "$ref": "#/definitions/identity-provider/definitions/entity_id"
+        },
+        "id": {
+          "$ref": "#/definitions/identity-provider/definitions/id"
+        },
+        "slo_target_url": {
+          "$ref": "#/definitions/identity-provider/definitions/slo_target_url"
+        },
+        "sso_target_url": {
+          "$ref": "#/definitions/identity-provider/definitions/sso_target_url"
+        },
+        "organization": {
+          "description": "organization associated with this identity provider",
+          "properties": {
+            "name": {
+              "$ref": "#/definitions/organization/definitions/name"
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ]
+        },
+        "updated_at": {
+          "$ref": "#/definitions/identity-provider/definitions/updated_at"
         }
       }
     },
@@ -7416,11 +7988,45 @@ module PlatformAPI
             "boolean"
           ]
         },
+        "verification_required": {
+          "description": "if the invitation requires verification",
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
         "token": {
           "description": "Unique identifier of an invitation",
           "example": "01234567-89ab-cdef-0123-456789abcdef",
           "format": "uuid",
           "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "phone_number": {
+          "description": "Phone number to send verification code",
+          "example": "+1 123-123-1234",
+          "type": [
+            "string"
+          ]
+        },
+        "method": {
+          "description": "Transport used to send verification code",
+          "example": "sms",
+          "default": "sms",
+          "type": [
+            "string"
+          ],
+          "enum": [
+            "call",
+            "sms"
+          ]
+        },
+        "verification_code": {
+          "description": "Value used to verify invitation",
+          "example": "123456",
           "type": [
             "string"
           ]
@@ -7433,6 +8039,73 @@ module PlatformAPI
           "method": "GET",
           "rel": "self",
           "title": "Info"
+        },
+        {
+          "description": "Invite a user.",
+          "href": "/invitations",
+          "method": "POST",
+          "rel": "self",
+          "schema": {
+            "properties": {
+              "email": {
+                "$ref": "#/definitions/account/definitions/email"
+              },
+              "name": {
+                "$ref": "#/definitions/account/definitions/name"
+              }
+            },
+            "required": [
+              "email",
+              "name"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Send a verification code for an invitation via SMS/phone call.",
+          "href": "/invitations/{(%23%2Fdefinitions%2Finvitation%2Fdefinitions%2Fidentity)}/actions/send-verification",
+          "method": "POST",
+          "rel": "empty",
+          "schema": {
+            "properties": {
+              "phone_number": {
+                "$ref": "#/definitions/invitation/definitions/phone_number"
+              },
+              "method": {
+                "$ref": "#/definitions/invitation/definitions/method"
+              }
+            },
+            "required": [
+              "phone_number"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "title": "Send Verification Code"
+        },
+        {
+          "description": "Verify an invitation using a verification code.",
+          "href": "/invitations/{(%23%2Fdefinitions%2Finvitation%2Fdefinitions%2Fidentity)}/actions/verify",
+          "method": "POST",
+          "rel": "self",
+          "schema": {
+            "properties": {
+              "verification_code": {
+                "$ref": "#/definitions/invitation/definitions/verification_code"
+              }
+            },
+            "required": [
+              "verification_code"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "title": "Verify"
         },
         {
           "description": "Finalize Invitation and Create Account.",
@@ -7459,34 +8132,13 @@ module PlatformAPI
               "object"
             ]
           },
-          "title": "Finalize Invitation"
-        },
-        {
-          "description": "Invite a user.",
-          "href": "/invitations",
-          "method": "POST",
-          "rel": "self",
-          "schema": {
-            "properties": {
-              "email": {
-                "$ref": "#/definitions/account/definitions/email"
-              },
-              "name": {
-                "$ref": "#/definitions/account/definitions/name"
-              }
-            },
-            "required": [
-              "email",
-              "name"
-            ],
-            "type": [
-              "object"
-            ]
-          },
-          "title": "Invitation"
+          "title": "Finalize"
         }
       ],
       "properties": {
+        "verification_required": {
+          "$ref": "#/definitions/invitation/definitions/verification_required"
+        },
         "created_at": {
           "$ref": "#/definitions/invitation/definitions/created_at"
         },
@@ -7909,39 +8561,6 @@ module PlatformAPI
       },
       "links": [
         {
-          "description": "Create a new key.",
-          "href": "/account/keys",
-          "method": "POST",
-          "rel": "create",
-          "schema": {
-            "properties": {
-              "public_key": {
-                "$ref": "#/definitions/key/definitions/public_key"
-              }
-            },
-            "required": [
-              "public_key"
-            ],
-            "type": [
-              "object"
-            ]
-          },
-          "targetSchema": {
-            "$ref": "#/definitions/key"
-          },
-          "title": "Create"
-        },
-        {
-          "description": "Delete an existing key",
-          "href": "/account/keys/{(%23%2Fdefinitions%2Fkey%2Fdefinitions%2Fidentity)}",
-          "method": "DELETE",
-          "rel": "destroy",
-          "targetSchema": {
-            "$ref": "#/definitions/key"
-          },
-          "title": "Delete"
-        },
-        {
           "description": "Info for existing key.",
           "href": "/account/keys/{(%23%2Fdefinitions%2Fkey%2Fdefinitions%2Fidentity)}",
           "method": "GET",
@@ -7992,7 +8611,7 @@ module PlatformAPI
       }
     },
     "log-drain": {
-      "description": "[Log drains](https://devcenter.heroku.com/articles/log-drains) provide a way to forward your Heroku logs to an external syslog server for long-term archiving. This external service must be configured to receive syslog packets from Heroku, whereupon its URL can be added to an app using this API. Some addons will add a log drain when they are provisioned to an app. These drains can only be removed by removing the add-on.",
+      "description": "[Log drains](https://devcenter.heroku.com/articles/log-drains) provide a way to forward your Heroku logs to an external syslog server for long-term archiving. This external service must be configured to receive syslog packets from Heroku, whereupon its URL can be added to an app using this API. Some add-ons will add a log drain when they are provisioned to an app. These drains can only be removed by removing the add-on.",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "stability": "production",
       "strictProperties": true,
@@ -8002,17 +8621,17 @@ module PlatformAPI
       ],
       "definitions": {
         "addon": {
-          "description": "addon that created the drain",
+          "description": "add-on that created the drain",
           "example": {
             "id": "01234567-89ab-cdef-0123-456789abcdef",
             "name": "singing-swiftly-1242"
           },
           "properties": {
             "id": {
-              "$ref": "#/definitions/addon/definitions/id"
+              "$ref": "#/definitions/add-on/definitions/id"
             },
             "name": {
-              "$ref": "#/definitions/addon/definitions/name"
+              "$ref": "#/definitions/add-on/definitions/name"
             }
           },
           "readOnly": true,
@@ -9045,7 +9664,7 @@ module PlatformAPI
         }
       }
     },
-    "organization-addon": {
+    "organization-add-on": {
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "description": "A list of add-ons the Organization uses across all apps",
       "stability": "production",
@@ -9061,7 +9680,7 @@ module PlatformAPI
           "rel": "instances",
           "targetSchema": {
             "items": {
-              "$ref": "#/definitions/addon"
+              "$ref": "#/definitions/add-on"
             },
             "type": [
               "array"
@@ -9194,6 +9813,9 @@ module PlatformAPI
           "properties": {
             "email": {
               "$ref": "#/definitions/account/definitions/email"
+            },
+            "federated": {
+              "$ref": "#/definitions/account/definitions/federated"
             },
             "id": {
               "$ref": "#/definitions/account/definitions/id"
@@ -9502,6 +10124,332 @@ module PlatformAPI
         }
       }
     },
+    "organization-feature": {
+      "description": "An organization feature represents a feature enabled on an organization account.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "prototype",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Organization Feature",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when organization feature was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "description": {
+          "description": "description of organization feature",
+          "example": "Causes account to example.",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "doc_url": {
+          "description": "documentation URL of organization feature",
+          "example": "http://devcenter.heroku.com/articles/example",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "enabled": {
+          "description": "whether or not account feature has been enabled",
+          "example": true,
+          "readOnly": false,
+          "type": [
+            "boolean"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of organization feature",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/organization-feature/definitions/id"
+            },
+            {
+              "$ref": "#/definitions/organization-feature/definitions/name"
+            }
+          ]
+        },
+        "name": {
+          "description": "unique name of organization feature",
+          "example": "name",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "state": {
+          "description": "state of organization feature",
+          "example": "public",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when organization feature was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Info for an existing account feature.",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/features/{(%23%2Fdefinitions%2Forganization-feature%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/organization-feature"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List existing organization features.",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/features",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/organization-feature"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/account-feature/definitions/created_at"
+        },
+        "description": {
+          "$ref": "#/definitions/account-feature/definitions/description"
+        },
+        "doc_url": {
+          "$ref": "#/definitions/account-feature/definitions/doc_url"
+        },
+        "enabled": {
+          "$ref": "#/definitions/account-feature/definitions/enabled"
+        },
+        "id": {
+          "$ref": "#/definitions/account-feature/definitions/id"
+        },
+        "name": {
+          "$ref": "#/definitions/account-feature/definitions/name"
+        },
+        "state": {
+          "$ref": "#/definitions/account-feature/definitions/state"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/account-feature/definitions/updated_at"
+        }
+      }
+    },
+    "organization-invitation": {
+      "description": "An organization invitation represents an invite to an organization.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "prototype",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Organization Invitation",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when invitation was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/organization-invitation/definitions/id"
+            }
+          ]
+        },
+        "id": {
+          "description": "Unique identifier of an invitation",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "token": {
+          "description": "Special token for invitation",
+          "example": "614ae25aa2d4802096cd7c18625b526c",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when invitation was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Get a list of an organization's Identity Providers",
+          "title": "List",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fname)}/invitations",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/organization-invitation"
+            },
+            "type": [
+              "array"
+            ]
+          }
+        },
+        {
+          "description": "Create Organization Invitation",
+          "title": "Create",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/invitations",
+          "method": "PUT",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "email": {
+                "$ref": "#/definitions/account/definitions/email"
+              },
+              "role": {
+                "$ref": "#/definitions/organization/definitions/role"
+              }
+            },
+            "required": [
+              "email",
+              "role"
+            ],
+            "type": [
+              "object"
+            ]
+          }
+        },
+        {
+          "description": "Revoke an organization invitation.",
+          "title": "Revoke",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/invitations/{(%23%2Fdefinitions%2Forganization-invitation%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "self"
+        },
+        {
+          "description": "Get an invitation by its token",
+          "title": "Get",
+          "href": "/organizations/invitations/{(%23%2Fdefinitions%2Forganization-invitation%2Fdefinitions%2Ftoken)}",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "$ref": "#/definitions/organization-invitation"
+          }
+        },
+        {
+          "description": "Accept Organization Invitation",
+          "title": "Accept",
+          "href": "/organizations/invitations/{(%23%2Fdefinitions%2Forganization-invitation%2Fdefinitions%2Ftoken)}/accept",
+          "method": "POST",
+          "rel": "create",
+          "targetSchema": {
+            "$ref": "#/definitions/organization-member"
+          }
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/organization-invitation/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/organization-invitation/definitions/id"
+        },
+        "invited_by": {
+          "properties": {
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            },
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/account/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "organization": {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/organization/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/organization/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "role": {
+          "$ref": "#/definitions/organization/definitions/role"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/organization-invitation/definitions/updated_at"
+        },
+        "user": {
+          "properties": {
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            },
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/account/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        }
+      }
+    },
     "organization-invoice": {
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "description": "An organization invoice is an itemized bill of goods for an organization which includes pricing and charges.",
@@ -9513,7 +10461,7 @@ module PlatformAPI
       ],
       "definitions": {
         "addons_total": {
-          "description": "total addons charges in on this invoice",
+          "description": "total add-ons charges in on this invoice",
           "example": 25000,
           "readOnly": true,
           "type": [
@@ -9789,6 +10737,15 @@ module PlatformAPI
             }
           ]
         },
+        "name": {
+          "description": "full name of the organization member",
+          "example": "Tina Edmonds",
+          "readOnly": true,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "two_factor_authentication": {
           "description": "whether the Enterprise organization member has two factor authentication enabled",
           "example": true,
@@ -9839,6 +10796,66 @@ module PlatformAPI
           "title": "Create or Update"
         },
         {
+          "description": "Create a new organization member.",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/members",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "email": {
+                "$ref": "#/definitions/organization-member/definitions/email"
+              },
+              "federated": {
+                "$ref": "#/definitions/organization-member/definitions/federated"
+              },
+              "role": {
+                "$ref": "#/definitions/organization/definitions/role"
+              }
+            },
+            "required": [
+              "email",
+              "role"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/organization-member"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Update an organization member.",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/members",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "email": {
+                "$ref": "#/definitions/organization-member/definitions/email"
+              },
+              "federated": {
+                "$ref": "#/definitions/organization-member/definitions/federated"
+              },
+              "role": {
+                "$ref": "#/definitions/organization/definitions/role"
+              }
+            },
+            "required": [
+              "email",
+              "role"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/organization-member"
+          },
+          "title": "update"
+        },
+        {
           "description": "Remove a member from the organization.",
           "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/members/{(%23%2Fdefinitions%2Forganization-member%2Fdefinitions%2Fidentity)}",
           "method": "DELETE",
@@ -9859,6 +10876,21 @@ module PlatformAPI
           "targetSchema": {
             "items": {
               "$ref": "#/definitions/organization-member"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "List the apps of a member.",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/members/{(%23%2Fdefinitions%2Forganization-member%2Fdefinitions%2Fidentity)}/apps",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/organization-app"
             },
             "type": [
               "array"
@@ -9897,6 +10929,9 @@ module PlatformAPI
             },
             "id": {
               "$ref": "#/definitions/account/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/account/definitions/name"
             }
           },
           "strictProperties": true,
@@ -9906,15 +10941,136 @@ module PlatformAPI
         }
       }
     },
-    "organization-payment-method": {
+    "organization-preferences": {
+      "description": "Tracks an organization's preferences",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
-      "description": "The on file payment method for an organization account.",
       "stability": "prototype",
-      "title": "Heroku Vault API - Organization Payment Method",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Organization Preferences",
       "type": [
         "object"
       ],
       "definitions": {
+        "default-permission": {
+          "description": "The default permission used when adding new members to the organization",
+          "example": "member",
+          "readOnly": false,
+          "enum": [
+            "admin",
+            "member",
+            "viewer",
+            null
+          ],
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "identity": {
+          "$ref": "#/definitions/organization/definitions/identity"
+        },
+        "whitelisting-enabled": {
+          "description": "Whether whitelisting rules should be applied to add-on installations",
+          "example": true,
+          "readOnly": false,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Retrieve Organization Preferences",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization-preferences%2Fdefinitions%2Fidentity)}/preferences",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/organization-preferences"
+          },
+          "title": "List"
+        },
+        {
+          "description": "Update Organization Preferences",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization-preferences%2Fdefinitions%2Fidentity)}/preferences",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "whitelisting-enabled": {
+                "$ref": "#/definitions/organization-preferences/definitions/whitelisting-enabled"
+              }
+            }
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/organization-preferences"
+          },
+          "title": "Update"
+        }
+      ],
+      "properties": {
+        "default-permission": {
+          "$ref": "#/definitions/organization-preferences/definitions/default-permission"
+        },
+        "whitelisting-enabled": {
+          "$ref": "#/definitions/organization-preferences/definitions/whitelisting-enabled"
+        }
+      }
+    },
+    "organization": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "description": "Organizations allow you to manage access to a shared group of applications across your development team.",
+      "stability": "prototype",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Organization",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when the organization was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "credit_card_collections": {
+          "description": "whether charges incurred by the org are paid by credit card.",
+          "example": true,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "default": {
+          "description": "whether to use this organization when none is specified",
+          "example": true,
+          "readOnly": false,
+          "type": [
+            "boolean"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of organization",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/organization/definitions/name"
+            },
+            {
+              "$ref": "#/definitions/organization/definitions/id"
+            }
+          ]
+        },
         "address_1": {
           "type": [
             "string"
@@ -10006,271 +11162,6 @@ module PlatformAPI
           "description": "state",
           "example": "CA"
         },
-        "card_last4": {
-          "type": [
-            "string"
-          ],
-          "description": "last 4 digits of credit card number",
-          "example": "1234",
-          "readOnly": true
-        },
-        "card_type": {
-          "type": [
-            "string"
-          ],
-          "description": "name of credit card issuer",
-          "example": "VISA",
-          "readOnly": true
-        },
-        "heroku_id": {
-          "type": [
-            "string"
-          ],
-          "description": "heroku_id identifier reference",
-          "example": "user930223902@heroku.com",
-          "readOnly": true
-        },
-        "identity": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/invoice-address/definitions/heroku_id"
-            }
-          ]
-        }
-      },
-      "links": [
-        {
-          "description": "Update an existing payment method for an organization account.",
-          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/payment-method",
-          "method": "PATCH",
-          "rel": "update",
-          "schema": {
-            "properties": {
-              "address_1": {
-                "$ref": "#/definitions/organization-payment-method/definitions/address_1"
-              },
-              "address_2": {
-                "$ref": "#/definitions/organization-payment-method/definitions/address_2"
-              },
-              "card_number": {
-                "$ref": "#/definitions/organization-payment-method/definitions/card_number"
-              },
-              "city": {
-                "$ref": "#/definitions/organization-payment-method/definitions/city"
-              },
-              "country": {
-                "$ref": "#/definitions/organization-payment-method/definitions/country"
-              },
-              "cvv": {
-                "$ref": "#/definitions/organization-payment-method/definitions/cvv"
-              },
-              "expiration_month": {
-                "$ref": "#/definitions/organization-payment-method/definitions/expiration_month"
-              },
-              "expiration_year": {
-                "$ref": "#/definitions/organization-payment-method/definitions/expiration_year"
-              },
-              "first_name": {
-                "$ref": "#/definitions/organization-payment-method/definitions/first_name"
-              },
-              "last_name": {
-                "$ref": "#/definitions/organization-payment-method/definitions/last_name"
-              },
-              "other": {
-                "$ref": "#/definitions/organization-payment-method/definitions/other"
-              },
-              "postal_code": {
-                "$ref": "#/definitions/organization-payment-method/definitions/postal_code"
-              },
-              "state": {
-                "$ref": "#/definitions/organization-payment-method/definitions/state"
-              }
-            },
-            "required": [
-              "address_1",
-              "address_2",
-              "card_number",
-              "city",
-              "country",
-              "cvv",
-              "expiration_month",
-              "expiration_year",
-              "first_name",
-              "last_name",
-              "postal_code",
-              "state"
-            ],
-            "type": [
-              "object"
-            ]
-          },
-          "title": "update"
-        },
-        {
-          "description": "Get the current payment method for an organization account.",
-          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/payment-method",
-          "method": "GET",
-          "rel": "self",
-          "targetSchema": {
-            "$ref": "#/definitions/organization-payment-method"
-          },
-          "title": "get"
-        }
-      ],
-      "properties": {
-        "address_1": {
-          "$ref": "#/definitions/organization-payment-method/definitions/address_1"
-        },
-        "address_2": {
-          "$ref": "#/definitions/organization-payment-method/definitions/address_2"
-        },
-        "card_last4": {
-          "$ref": "#/definitions/organization-payment-method/definitions/card_last4"
-        },
-        "card_type": {
-          "$ref": "#/definitions/organization-payment-method/definitions/card_type"
-        },
-        "city": {
-          "$ref": "#/definitions/organization-payment-method/definitions/city"
-        },
-        "country": {
-          "$ref": "#/definitions/organization-payment-method/definitions/country"
-        },
-        "expiration_month": {
-          "$ref": "#/definitions/organization-payment-method/definitions/expiration_month"
-        },
-        "expiration_year": {
-          "$ref": "#/definitions/organization-payment-method/definitions/expiration_year"
-        },
-        "first_name": {
-          "$ref": "#/definitions/organization-payment-method/definitions/first_name"
-        },
-        "last_name": {
-          "$ref": "#/definitions/organization-payment-method/definitions/last_name"
-        },
-        "other": {
-          "$ref": "#/definitions/organization-payment-method/definitions/other"
-        },
-        "postal_code": {
-          "$ref": "#/definitions/organization-payment-method/definitions/postal_code"
-        },
-        "state": {
-          "$ref": "#/definitions/organization-payment-method/definitions/state"
-        }
-      }
-    },
-    "organization-preferences": {
-      "description": "Tracks an organization's preferences",
-      "$schema": "http://json-schema.org/draft-04/hyper-schema",
-      "stability": "prototype",
-      "strictProperties": true,
-      "title": "Heroku Platform API - Organization Preferences",
-      "type": [
-        "object"
-      ],
-      "definitions": {
-        "identity": {
-          "$ref": "#/definitions/organization/definitions/identity"
-        },
-        "whitelisting-enabled": {
-          "description": "Whether whitelisting rules should be applied to add-on installations",
-          "example": true,
-          "readOnly": false,
-          "type": [
-            "boolean",
-            "null"
-          ]
-        }
-      },
-      "links": [
-        {
-          "description": "Retrieve Organization Preferences",
-          "href": "/organizations/{(%23%2Fdefinitions%2Forganization-preferences%2Fdefinitions%2Fidentity)}/preferences",
-          "method": "GET",
-          "rel": "self",
-          "targetSchema": {
-            "$ref": "#/definitions/organization-preferences"
-          },
-          "title": "List"
-        },
-        {
-          "description": "Update Organization Preferences",
-          "href": "/organizations/{(%23%2Fdefinitions%2Forganization-preferences%2Fdefinitions%2Fidentity)}/preferences",
-          "method": "PATCH",
-          "rel": "update",
-          "schema": {
-            "properties": {
-              "whitelisting-enabled": {
-                "$ref": "#/definitions/organization-preferences/definitions/whitelisting-enabled"
-              }
-            }
-          },
-          "targetSchema": {
-            "$ref": "#/definitions/organization-preferences"
-          },
-          "title": "Update"
-        }
-      ],
-      "properties": {
-        "whitelisting-enabled": {
-          "$ref": "#/definitions/organization-preferences/definitions/whitelisting-enabled"
-        }
-      }
-    },
-    "organization": {
-      "$schema": "http://json-schema.org/draft-04/hyper-schema",
-      "description": "Organizations allow you to manage access to a shared group of applications across your development team.",
-      "stability": "prototype",
-      "strictProperties": true,
-      "title": "Heroku Platform API - Organization",
-      "type": [
-        "object"
-      ],
-      "definitions": {
-        "created_at": {
-          "description": "when the organization was created",
-          "example": "2012-01-01T12:00:00Z",
-          "format": "date-time",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "credit_card_collections": {
-          "description": "whether charges incurred by the org are paid by credit card.",
-          "example": true,
-          "readOnly": true,
-          "type": [
-            "boolean"
-          ]
-        },
-        "default": {
-          "description": "whether to use this organization when none is specified",
-          "example": true,
-          "readOnly": false,
-          "type": [
-            "boolean"
-          ]
-        },
-        "id": {
-          "description": "unique identifier of organization",
-          "example": "01234567-89ab-cdef-0123-456789abcdef",
-          "format": "uuid",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "identity": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/organization/definitions/name"
-            },
-            {
-              "$ref": "#/definitions/organization/definitions/id"
-            }
-          ]
-        },
         "membership_limit": {
           "description": "upper limit of members allowed in an organization.",
           "example": 25,
@@ -10358,7 +11249,7 @@ module PlatformAPI
           "title": "Info"
         },
         {
-          "description": "Set or unset the organization as your default organization.",
+          "description": "Update organization properties.",
           "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}",
           "method": "PATCH",
           "rel": "update",
@@ -10366,6 +11257,9 @@ module PlatformAPI
             "properties": {
               "default": {
                 "$ref": "#/definitions/organization/definitions/default"
+              },
+              "name": {
+                "$ref": "#/definitions/organization/definitions/name"
               }
             },
             "type": [
@@ -10388,43 +11282,43 @@ module PlatformAPI
                 "$ref": "#/definitions/organization/definitions/name"
               },
               "address_1": {
-                "$ref": "#/definitions/payment-method/definitions/address_1"
+                "$ref": "#/definitions/organization/definitions/address_1"
               },
               "address_2": {
-                "$ref": "#/definitions/payment-method/definitions/address_2"
+                "$ref": "#/definitions/organization/definitions/address_2"
               },
               "card_number": {
-                "$ref": "#/definitions/payment-method/definitions/card_number"
+                "$ref": "#/definitions/organization/definitions/card_number"
               },
               "city": {
-                "$ref": "#/definitions/payment-method/definitions/city"
+                "$ref": "#/definitions/organization/definitions/city"
               },
               "country": {
-                "$ref": "#/definitions/payment-method/definitions/country"
+                "$ref": "#/definitions/organization/definitions/country"
               },
               "cvv": {
-                "$ref": "#/definitions/payment-method/definitions/cvv"
+                "$ref": "#/definitions/organization/definitions/cvv"
               },
               "expiration_month": {
-                "$ref": "#/definitions/payment-method/definitions/expiration_month"
+                "$ref": "#/definitions/organization/definitions/expiration_month"
               },
               "expiration_year": {
-                "$ref": "#/definitions/payment-method/definitions/expiration_year"
+                "$ref": "#/definitions/organization/definitions/expiration_year"
               },
               "first_name": {
-                "$ref": "#/definitions/payment-method/definitions/first_name"
+                "$ref": "#/definitions/organization/definitions/first_name"
               },
               "last_name": {
-                "$ref": "#/definitions/payment-method/definitions/last_name"
+                "$ref": "#/definitions/organization/definitions/last_name"
               },
               "other": {
-                "$ref": "#/definitions/payment-method/definitions/other"
+                "$ref": "#/definitions/organization/definitions/other"
               },
               "postal_code": {
-                "$ref": "#/definitions/payment-method/definitions/postal_code"
+                "$ref": "#/definitions/organization/definitions/postal_code"
               },
               "state": {
-                "$ref": "#/definitions/payment-method/definitions/state"
+                "$ref": "#/definitions/organization/definitions/state"
               }
             },
             "required": [
@@ -10480,86 +11374,6 @@ module PlatformAPI
         },
         "updated_at": {
           "$ref": "#/definitions/organization/definitions/updated_at"
-        }
-      }
-    },
-    "otp-secret": {
-      "description": "This renders a secret that clients can use to build a one-time password to be supplied as a 2nd factor of authentication.",
-      "$schema": "http://json-schema.org/draft-04/hyper-schema",
-      "stability": "development",
-      "strictProperties": true,
-      "title": "Heroku Platform API - OTP Secret",
-      "type": [
-        "object"
-      ],
-      "definitions": {
-        "created_at": {
-          "description": "when OTP secret was created",
-          "example": "2012-01-01T12:00:00Z",
-          "format": "date-time",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "id": {
-          "description": "unique identifier of OTP secret",
-          "example": "01234567-89ab-cdef-0123-456789abcdef",
-          "format": "uuid",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "identity": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/otp-secret/definitions/id"
-            }
-          ]
-        },
-        "updated_at": {
-          "description": "when OTP secret was updated",
-          "example": "2012-01-01T12:00:00Z",
-          "format": "date-time",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "url": {
-          "description": "OTP secret rendered in URL format",
-          "example": "otpauth://totp/username@example.com?issuer=Heroku&secret=abcd1234",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        }
-      },
-      "links": [
-        {
-          "description": "Create new OTP secret. This invalidates any existing OTP secrets on the account.",
-          "href": "/account/otp-secret",
-          "method": "POST",
-          "rel": "create",
-          "targetSchema": {
-            "$ref": "#/definitions/otp-secret"
-          },
-          "title": "Create"
-        }
-      ],
-      "properties": {
-        "created_at": {
-          "$ref": "#/definitions/otp-secret/definitions/created_at"
-        },
-        "id": {
-          "$ref": "#/definitions/otp-secret/definitions/id"
-        },
-        "updated_at": {
-          "$ref": "#/definitions/otp-secret/definitions/updated_at"
-        },
-        "url": {
-          "$ref": "#/definitions/otp-secret/definitions/url"
         }
       }
     },
@@ -10829,421 +11643,6 @@ module PlatformAPI
           "type": [
             "object"
           ]
-        }
-      }
-    },
-    "payment-method": {
-      "$schema": "http://json-schema.org/draft-04/hyper-schema",
-      "description": "The on file payment method for an account",
-      "stability": "prototype",
-      "title": "Heroku Vault API - Payment Method",
-      "type": [
-        "object"
-      ],
-      "definitions": {
-        "address_1": {
-          "type": [
-            "string"
-          ],
-          "description": "street address line 1",
-          "example": "40 Hickory Lane"
-        },
-        "address_2": {
-          "type": [
-            "string"
-          ],
-          "description": "street address line 2",
-          "example": "Suite 103"
-        },
-        "card_number": {
-          "type": [
-            "string"
-          ],
-          "description": "encrypted card number of payment method",
-          "example": "encrypted-card-number"
-        },
-        "city": {
-          "type": [
-            "string"
-          ],
-          "description": "city",
-          "example": "San Francisco"
-        },
-        "country": {
-          "type": [
-            "string"
-          ],
-          "description": "country",
-          "example": "US"
-        },
-        "cvv": {
-          "type": [
-            "string"
-          ],
-          "description": "card verification value",
-          "example": "123"
-        },
-        "expiration_month": {
-          "type": [
-            "string"
-          ],
-          "description": "expiration month",
-          "example": "11"
-        },
-        "expiration_year": {
-          "type": [
-            "string"
-          ],
-          "description": "expiration year",
-          "example": "2014"
-        },
-        "first_name": {
-          "type": [
-            "string"
-          ],
-          "description": "the first name for payment method",
-          "example": "Jason"
-        },
-        "last_name": {
-          "type": [
-            "string"
-          ],
-          "description": "the last name for payment method",
-          "example": "Walker"
-        },
-        "other": {
-          "type": [
-            "string"
-          ],
-          "description": "metadata",
-          "example": "Additional information for payment method"
-        },
-        "postal_code": {
-          "type": [
-            "string"
-          ],
-          "description": "postal code",
-          "example": "90210"
-        },
-        "state": {
-          "type": [
-            "string"
-          ],
-          "description": "state",
-          "example": "CA"
-        },
-        "card_last4": {
-          "type": [
-            "string"
-          ],
-          "description": "last 4 digits of credit card number",
-          "example": "1234",
-          "readOnly": true
-        },
-        "card_type": {
-          "type": [
-            "string"
-          ],
-          "description": "name of credit card issuer",
-          "example": "VISA",
-          "readOnly": true
-        },
-        "heroku_id": {
-          "type": [
-            "string"
-          ],
-          "description": "heroku_id identifier reference",
-          "example": "user930223902@heroku.com",
-          "readOnly": true
-        },
-        "identity": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/invoice-address/definitions/heroku_id"
-            }
-          ]
-        }
-      },
-      "links": [
-        {
-          "description": "Update an existing payment method for an account.",
-          "href": "/account/payment-method",
-          "method": "PATCH",
-          "rel": "update",
-          "schema": {
-            "properties": {
-              "address_1": {
-                "$ref": "#/definitions/payment-method/definitions/address_1"
-              },
-              "address_2": {
-                "$ref": "#/definitions/payment-method/definitions/address_2"
-              },
-              "card_number": {
-                "$ref": "#/definitions/payment-method/definitions/card_number"
-              },
-              "city": {
-                "$ref": "#/definitions/payment-method/definitions/city"
-              },
-              "country": {
-                "$ref": "#/definitions/payment-method/definitions/country"
-              },
-              "cvv": {
-                "$ref": "#/definitions/payment-method/definitions/cvv"
-              },
-              "expiration_month": {
-                "$ref": "#/definitions/payment-method/definitions/expiration_month"
-              },
-              "expiration_year": {
-                "$ref": "#/definitions/payment-method/definitions/expiration_year"
-              },
-              "first_name": {
-                "$ref": "#/definitions/payment-method/definitions/first_name"
-              },
-              "last_name": {
-                "$ref": "#/definitions/payment-method/definitions/last_name"
-              },
-              "other": {
-                "$ref": "#/definitions/payment-method/definitions/other"
-              },
-              "postal_code": {
-                "$ref": "#/definitions/payment-method/definitions/postal_code"
-              },
-              "state": {
-                "$ref": "#/definitions/payment-method/definitions/state"
-              }
-            },
-            "required": [
-              "address_1",
-              "address_2",
-              "card_number",
-              "city",
-              "country",
-              "cvv",
-              "expiration_month",
-              "expiration_year",
-              "first_name",
-              "last_name",
-              "postal_code",
-              "state"
-            ],
-            "type": [
-              "object"
-            ]
-          },
-          "title": "update"
-        },
-        {
-          "description": "Get the current payment method for an account.",
-          "href": "/account/payment-method",
-          "method": "GET",
-          "rel": "self",
-          "targetSchema": {
-            "$ref": "#/definitions/payment-method"
-          },
-          "title": "get"
-        }
-      ],
-      "properties": {
-        "address_1": {
-          "$ref": "#/definitions/payment-method/definitions/address_1"
-        },
-        "address_2": {
-          "$ref": "#/definitions/payment-method/definitions/address_2"
-        },
-        "card_last4": {
-          "$ref": "#/definitions/payment-method/definitions/card_last4"
-        },
-        "card_type": {
-          "$ref": "#/definitions/payment-method/definitions/card_type"
-        },
-        "city": {
-          "$ref": "#/definitions/payment-method/definitions/city"
-        },
-        "country": {
-          "$ref": "#/definitions/payment-method/definitions/country"
-        },
-        "expiration_month": {
-          "$ref": "#/definitions/payment-method/definitions/expiration_month"
-        },
-        "expiration_year": {
-          "$ref": "#/definitions/payment-method/definitions/expiration_year"
-        },
-        "first_name": {
-          "$ref": "#/definitions/payment-method/definitions/first_name"
-        },
-        "last_name": {
-          "$ref": "#/definitions/payment-method/definitions/last_name"
-        },
-        "other": {
-          "$ref": "#/definitions/payment-method/definitions/other"
-        },
-        "postal_code": {
-          "$ref": "#/definitions/payment-method/definitions/postal_code"
-        },
-        "state": {
-          "$ref": "#/definitions/payment-method/definitions/state"
-        }
-      }
-    },
-    "payment": {
-      "$schema": "http://json-schema.org/draft-04/hyper-schema",
-      "description": "A payment represents money collected for an account",
-      "title": "Heroku Vault API - Payments",
-      "stability": "prototype",
-      "type": [
-        "object"
-      ],
-      "definitions": {
-        "account_id": {
-          "type": [
-            "integer"
-          ],
-          "description": "account that payment belongs to",
-          "example": 8403923,
-          "readOnly": true
-        },
-        "amount": {
-          "type": [
-            "number"
-          ],
-          "description": "amount of payment in cents",
-          "example": 50000,
-          "readOnly": false
-        },
-        "created_at": {
-          "description": "when payment was created",
-          "example": "2012-01-01T12:00:00Z",
-          "format": "date-time",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "id": {
-          "type": [
-            "integer"
-          ],
-          "description": "legacy unique identifier of payment",
-          "example": 9403943,
-          "readOnly": true
-        },
-        "identity": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/payment/definitions/id"
-            }
-          ]
-        },
-        "state": {
-          "enum": [
-            "failure",
-            "pending",
-            "success"
-          ],
-          "type": [
-            "string"
-          ],
-          "description": "state of the payment",
-          "example": "pending",
-          "readOnly": true
-        },
-        "updated_at": {
-          "description": "when credit was updated",
-          "example": "2012-01-01T12:00:00Z",
-          "format": "date-time",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "uuid": {
-          "description": "unique identifier for a payment transaction",
-          "example": "01234567-89ab-cdef-0123-456789abcdef",
-          "format": "uuid",
-          "readOnly": false,
-          "type": [
-            "string"
-          ]
-        }
-      },
-      "links": [
-        {
-          "description": "Create a payment on an existing account",
-          "href": "/account/payments",
-          "method": "POST",
-          "rel": "self",
-          "schema": {
-            "properties": {
-              "amount": {
-                "$ref": "#/definitions/payment/definitions/amount"
-              },
-              "invoice": {
-                "$ref": "#/definitions/invoice/definitions/identity"
-              },
-              "uuid": {
-                "$ref": "#/definitions/payment/definitions/uuid"
-              }
-            },
-            "required": [
-              "amount",
-              "invoice",
-              "uuid"
-            ],
-            "type": [
-              "object"
-            ]
-          },
-          "targetSchema": {
-            "$ref": "#/definitions/payment"
-          },
-          "title": "create"
-        }
-      ],
-      "properties": {
-        "amount": {
-          "$ref": "#/definitions/payment/definitions/amount"
-        },
-        "created_at": {
-          "$ref": "#/definitions/payment/definitions/created_at"
-        },
-        "id": {
-          "$ref": "#/definitions/payment/definitions/id"
-        },
-        "invoice": {
-          "description": "identity of invoice",
-          "properties": {
-            "id": {
-              "$ref": "#/definitions/invoice/definitions/id"
-            },
-            "number": {
-              "$ref": "#/definitions/invoice/definitions/number"
-            }
-          },
-          "type": [
-            "null",
-            "object"
-          ]
-        },
-        "updated_at": {
-          "$ref": "#/definitions/payment/definitions/updated_at"
-        },
-        "user": {
-          "description": "identity of user issuing payment",
-          "properties": {
-            "email": {
-              "$ref": "#/definitions/account/definitions/email"
-            },
-            "id": {
-              "$ref": "#/definitions/account/definitions/id"
-            }
-          },
-          "strictProperties": true,
-          "type": [
-            "object"
-          ]
-        },
-        "state": {
-          "$ref": "#/definitions/payment/definitions/state"
         }
       }
     },
@@ -11992,8 +12391,22 @@ module PlatformAPI
             "string"
           ]
         },
+        "compliance": {
+          "description": "the compliance regimes applied to an add-on plan",
+          "example": [
+            "HIPAA"
+          ],
+          "readOnly": false,
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "$ref": "#/definitions/plan/definitions/regime"
+          }
+        },
         "default": {
-          "description": "whether this plan is the default for its addon service",
+          "description": "whether this plan is the default for its add-on service",
           "example": false,
           "readOnly": true,
           "type": [
@@ -12009,7 +12422,7 @@ module PlatformAPI
           ]
         },
         "human_name": {
-          "description": "human readable name of the addon plan",
+          "description": "human readable name of the add-on plan",
           "example": "Dev",
           "readOnly": true,
           "type": [
@@ -12059,6 +12472,18 @@ module PlatformAPI
             "string"
           ]
         },
+        "regime": {
+          "description": "compliance requirements an add-on plan must adhere to",
+          "readOnly": true,
+          "example": "HIPAA",
+          "type": [
+            "string"
+          ],
+          "enum": [
+            "HIPAA",
+            "PCI"
+          ]
+        },
         "cents": {
           "description": "price in cents per unit of plan",
           "example": 0,
@@ -12099,12 +12524,20 @@ module PlatformAPI
           "type": [
             "string"
           ]
+        },
+        "visible": {
+          "description": "whether this plan is publicly visible",
+          "example": true,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
         }
       },
       "links": [
         {
           "description": "Info for existing plan.",
-          "href": "/addon-services/{(%23%2Fdefinitions%2Faddon-service%2Fdefinitions%2Fidentity)}/plans/{(%23%2Fdefinitions%2Fplan%2Fdefinitions%2Fidentity)}",
+          "href": "/addon-services/{(%23%2Fdefinitions%2Fadd-on-service%2Fdefinitions%2Fidentity)}/plans/{(%23%2Fdefinitions%2Fplan%2Fdefinitions%2Fidentity)}",
           "method": "GET",
           "rel": "self",
           "targetSchema": {
@@ -12114,7 +12547,7 @@ module PlatformAPI
         },
         {
           "description": "List existing plans.",
-          "href": "/addon-services/{(%23%2Fdefinitions%2Faddon-service%2Fdefinitions%2Fidentity)}/plans",
+          "href": "/addon-services/{(%23%2Fdefinitions%2Fadd-on-service%2Fdefinitions%2Fidentity)}/plans",
           "method": "GET",
           "rel": "instances",
           "targetSchema": {
@@ -12133,10 +12566,10 @@ module PlatformAPI
           "description": "identity of add-on service",
           "properties": {
             "id": {
-              "$ref": "#/definitions/addon-service/definitions/id"
+              "$ref": "#/definitions/add-on-service/definitions/id"
             },
             "name": {
-              "$ref": "#/definitions/addon-service/definitions/name"
+              "$ref": "#/definitions/add-on-service/definitions/name"
             }
           },
           "strictProperties": true,
@@ -12146,6 +12579,9 @@ module PlatformAPI
         },
         "created_at": {
           "$ref": "#/definitions/plan/definitions/created_at"
+        },
+        "compliance": {
+          "$ref": "#/definitions/plan/definitions/compliance"
         },
         "default": {
           "$ref": "#/definitions/plan/definitions/default"
@@ -12191,6 +12627,9 @@ module PlatformAPI
         },
         "updated_at": {
           "$ref": "#/definitions/plan/definitions/updated_at"
+        },
+        "visible": {
+          "$ref": "#/definitions/plan/definitions/visible"
         }
       }
     },
@@ -12232,34 +12671,6 @@ module PlatformAPI
           "$ref": "#/definitions/rate-limit/definitions/remaining"
         }
       }
-    },
-    "recovery-code": {
-      "description": "Recovery codes grant access to accounts with two-factor authentication enabled.",
-      "$schema": "http://json-schema.org/draft-04/hyper-schema",
-      "stability": "development",
-      "strictProperties": true,
-      "title": "Heroku Platform API - Recovery Code",
-      "type": [
-        "array"
-      ],
-      "items": {
-        "example": "0123456789abcdef",
-        "type": [
-          "string"
-        ]
-      },
-      "links": [
-        {
-          "description": "Generate new recovery codes. This invalidates any existing codes on the account.",
-          "href": "/account/recovery-codes",
-          "method": "POST",
-          "rel": "create",
-          "targetSchema": {
-            "$ref": "#/definitions/recovery-code"
-          },
-          "title": "Create"
-        }
-      ]
     },
     "region": {
       "description": "A region represents a geographic location in which your application may run.",
@@ -12593,6 +13004,15 @@ module PlatformAPI
         }
       ],
       "properties": {
+        "addon_plan_names": {
+          "description": "add-on plans installed on the app for this release",
+          "type": [
+            "array"
+          ],
+          "items": {
+            "$ref": "#/definitions/plan/definitions/name"
+          }
+        },
         "app": {
           "description": "app involved in the release",
           "properties": {
@@ -12744,7 +13164,7 @@ module PlatformAPI
             "web": "./bin/web -p $PORT"
           },
           "patternProperties": {
-            "^\\w+$": {
+            "^[-\\w]{1,128}$": {
               "type": [
                 "string"
               ]
@@ -12966,6 +13386,305 @@ module PlatformAPI
         }
       }
     },
+    "sni-endpoint": {
+      "description": "SNI Endpoint is a public address serving a custom SSL cert for HTTPS traffic, using the SNI TLS extension, to a Heroku app. Note: only apps with the `http-sni` and `stable-cname` feature flags or those owned by a user with the `user-http-sni` and `user-stable-cname` feature flags are authorized to use this endpoint.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "title": "Heroku Platform API - SNI Endpoint",
+      "stability": "prototype",
+      "strictProperties": true,
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "app": {
+          "description": "app receiving the new endpoint",
+          "example": "253c2ffd-192d-4a6f-913e-2f7af25a87ef",
+          "format": "uuid",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "ca_signed?": {
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "cert_domains": {
+          "readOnly": true,
+          "type": [
+            "array"
+          ]
+        },
+        "certificate_chain": {
+          "description": "raw contents of the public certificate chain (eg: .crt or .pem file)",
+          "example": "-----BEGIN CERTIFICATE----- ...",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "cname": {
+          "description": "canonical name record, the address to point a domain at",
+          "example": "example.herokussl.com",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "created_at": {
+          "description": "when endpoint was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "expires_at": {
+          "readOnly": true,
+          "format": "date-time",
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of this SNI endpoint",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/sni-endpoint/definitions/id"
+            },
+            {
+              "$ref": "#/definitions/sni-endpoint/definitions/name"
+            }
+          ]
+        },
+        "issuer": {
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "name": {
+          "description": "unique name for SNI endpoint",
+          "example": "example",
+          "pattern": "^[a-z][a-z0-9-]{2,29}$",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "private_key": {
+          "description": "contents of the private key (eg .key file)",
+          "example": "-----BEGIN RSA PRIVATE KEY----- ...",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "self_signed?": {
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "starts_at": {
+          "readOnly": true,
+          "format": "date-time",
+          "type": [
+            "string"
+          ]
+        },
+        "subject": {
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when SNI endpoint was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Create a new SNI endpoint.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/sni-endpoints",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "app": {
+                "$ref": "#/definitions/sni-endpoint/definitions/app"
+              },
+              "certificate_chain": {
+                "$ref": "#/definitions/sni-endpoint/definitions/certificate_chain"
+              },
+              "private_key": {
+                "$ref": "#/definitions/sni-endpoint/definitions/private_key"
+              }
+            },
+            "required": [
+              "certificate_chain",
+              "private_key"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/sni-endpoint"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Delete existing SNI endpoint.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/sni-endpoints/{(%23%2Fdefinitions%2Fsni-endpoint%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/sni-endpoint"
+          },
+          "title": "Delete"
+        },
+        {
+          "description": "Info for existing SNI endpoint.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/sni-endpoints/{(%23%2Fdefinitions%2Fsni-endpoint%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/sni-endpoint"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List existing SNI endpoints.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/sni-endpoints",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/sni-endpoint"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "Update an existing SNI endpoint.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/sni-endpoints/{(%23%2Fdefinitions%2Fsni-endpoint%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "certificate_chain": {
+                "$ref": "#/definitions/sni-endpoint/definitions/certificate_chain"
+              },
+              "private_key": {
+                "$ref": "#/definitions/sni-endpoint/definitions/private_key"
+              }
+            },
+            "required": [
+              "certificate_chain",
+              "private_key"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/sni-endpoint"
+          },
+          "title": "Update"
+        }
+      ],
+      "properties": {
+        "app": {
+          "description": "application associated with this sni-endpoint",
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/app/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/app/definitions/name"
+            }
+          },
+          "strictProperties": true
+        },
+        "certificate_chain": {
+          "$ref": "#/definitions/sni-endpoint/definitions/certificate_chain"
+        },
+        "cname": {
+          "$ref": "#/definitions/sni-endpoint/definitions/cname"
+        },
+        "created_at": {
+          "$ref": "#/definitions/sni-endpoint/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/sni-endpoint/definitions/id"
+        },
+        "name": {
+          "$ref": "#/definitions/sni-endpoint/definitions/name"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/sni-endpoint/definitions/updated_at"
+        },
+        "ssl_cert": {
+          "description": "certificate provided by this endpoint",
+          "properties": {
+            "ca_signed?": {
+              "$ref": "#/definitions/sni-endpoint/definitions/ca_signed?"
+            },
+            "cert_domains": {
+              "$ref": "#/definitions/sni-endpoint/definitions/cert_domains"
+            },
+            "expires_at": {
+              "$ref": "#/definitions/sni-endpoint/definitions/expires_at"
+            },
+            "issuer": {
+              "$ref": "#/definitions/sni-endpoint/definitions/issuer"
+            },
+            "self_signed?": {
+              "$ref": "#/definitions/sni-endpoint/definitions/self_signed?"
+            },
+            "starts_at": {
+              "$ref": "#/definitions/sni-endpoint/definitions/starts_at"
+            },
+            "subject": {
+              "$ref": "#/definitions/sni-endpoint/definitions/subject"
+            },
+            "id": {
+              "description": "unique identifier of this SSL certificate",
+              "example": "01234567-89ab-cdef-0123-456789abcdef",
+              "format": "uuid",
+              "readOnly": true,
+              "type": [
+                "string"
+              ]
+            }
+          }
+        }
+      }
+    },
     "source": {
       "description": "A source is a location for uploading and downloading an application's source code.",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
@@ -13013,7 +13732,7 @@ module PlatformAPI
           "targetSchema": {
             "$ref": "#/definitions/source"
           },
-          "title": "Create (Deprecated)"
+          "title": "Create - Deprecated"
         }
       ],
       "properties": {
@@ -13280,32 +13999,6 @@ module PlatformAPI
         "object"
       ],
       "definitions": {
-        "regime": {
-          "description": "compliance requirements a space must adhere to",
-          "readOnly": true,
-          "example": "HIPAA",
-          "type": [
-            "string"
-          ],
-          "enum": [
-            "HIPAA",
-            "PCI"
-          ]
-        },
-        "compliance": {
-          "description": "the compliance regimes applied to a space",
-          "example": [
-            "HIPAA"
-          ],
-          "readOnly": false,
-          "type": [
-            "null",
-            "array"
-          ],
-          "items": {
-            "$ref": "#/definitions/space/definitions/regime"
-          }
-        },
         "created_at": {
           "description": "when space was created",
           "example": "2012-01-01T12:00:00Z",
@@ -13341,6 +14034,14 @@ module PlatformAPI
           "pattern": "^[a-z0-9](?:[a-z0-9]|-(?!-))+[a-z0-9]$",
           "type": [
             "string"
+          ]
+        },
+        "shield": {
+          "description": "true if this space has shield enabled",
+          "readOnly": true,
+          "example": true,
+          "type": [
+            "boolean"
           ]
         },
         "state": {
@@ -13432,15 +14133,19 @@ module PlatformAPI
               "name": {
                 "$ref": "#/definitions/space/definitions/name"
               },
+              "organization": {
+                "$ref": "#/definitions/organization/definitions/name"
+              },
               "region": {
                 "$ref": "#/definitions/region/definitions/identity"
               },
-              "compliance": {
-                "$ref": "#/definitions/space/definitions/compliance"
+              "shield": {
+                "$ref": "#/definitions/space/definitions/shield"
               }
             },
             "required": [
-              "name"
+              "name",
+              "organization"
             ],
             "type": [
               "object"
@@ -13453,9 +14158,6 @@ module PlatformAPI
         }
       ],
       "properties": {
-        "compliance": {
-          "$ref": "#/definitions/space/definitions/compliance"
-        },
         "created_at": {
           "$ref": "#/definitions/space/definitions/created_at"
         },
@@ -13473,7 +14175,6 @@ module PlatformAPI
             }
           },
           "type": [
-            "null",
             "object"
           ]
         },
@@ -13492,6 +14193,9 @@ module PlatformAPI
             "object"
           ]
         },
+        "shield": {
+          "$ref": "#/definitions/space/definitions/shield"
+        },
         "state": {
           "$ref": "#/definitions/space/definitions/state"
         },
@@ -13501,7 +14205,7 @@ module PlatformAPI
       }
     },
     "ssl-endpoint": {
-      "description": "[SSL Endpoint](https://devcenter.heroku.com/articles/ssl-endpoint) is a public address serving custom SSL cert for HTTPS traffic to a Heroku app. Note that an app must have the `ssl:endpoint` addon installed before it can provision an SSL Endpoint using these APIs.",
+      "description": "[SSL Endpoint](https://devcenter.heroku.com/articles/ssl-endpoint) is a public address serving custom SSL cert for HTTPS traffic to a Heroku app. Note that an app must have the `ssl:endpoint` add-on installed before it can provision an SSL Endpoint using these APIs.",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "title": "Heroku Platform API - SSL Endpoint",
       "stability": "production",
@@ -13696,6 +14400,21 @@ module PlatformAPI
         }
       ],
       "properties": {
+        "app": {
+          "description": "application associated with this ssl-endpoint",
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/app/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/app/definitions/name"
+            }
+          },
+          "strictProperties": true
+        },
         "certificate_chain": {
           "$ref": "#/definitions/ssl-endpoint/definitions/certificate_chain"
         },
@@ -14038,7 +14757,7 @@ module PlatformAPI
         }
       }
     },
-    "whitelisted-addon-service": {
+    "whitelisted-add-on-service": {
       "description": "Entities that have been whitelisted to be used by an Organization",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "stability": "prototype",
@@ -14061,10 +14780,18 @@ module PlatformAPI
           "description": "the user which whitelisted the Add-on Service",
           "properties": {
             "email": {
-              "$ref": "#/definitions/account/definitions/email"
+              "$ref": "#/definitions/account/definitions/email",
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "id": {
-              "$ref": "#/definitions/account/definitions/id"
+              "$ref": "#/definitions/account/definitions/id",
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "readOnly": true,
@@ -14076,13 +14803,13 @@ module PlatformAPI
           "description": "the Add-on Service whitelisted for use",
           "properties": {
             "id": {
-              "$ref": "#/definitions/addon-service/definitions/id"
+              "$ref": "#/definitions/add-on-service/definitions/id"
             },
             "name": {
-              "$ref": "#/definitions/addon-service/definitions/name"
+              "$ref": "#/definitions/add-on-service/definitions/name"
             },
             "human_name": {
-              "$ref": "#/definitions/addon-service/definitions/human_name"
+              "$ref": "#/definitions/add-on-service/definitions/human_name"
             }
           },
           "readOnly": true,
@@ -14102,10 +14829,10 @@ module PlatformAPI
         "identity": {
           "anyOf": [
             {
-              "$ref": "#/definitions/whitelisted-addon-service/definitions/id"
+              "$ref": "#/definitions/whitelisted-add-on-service/definitions/id"
             },
             {
-              "$ref": "#/definitions/addon-service/definitions/name"
+              "$ref": "#/definitions/add-on-service/definitions/name"
             }
           ]
         }
@@ -14118,7 +14845,7 @@ module PlatformAPI
           "rel": "instances",
           "targetSchema": {
             "items": {
-              "$ref": "#/definitions/whitelisted-addon-service"
+              "$ref": "#/definitions/whitelisted-add-on-service"
             },
             "type": [
               "array"
@@ -14144,7 +14871,7 @@ module PlatformAPI
           },
           "targetSchema": {
             "items": {
-              "$ref": "#/definitions/whitelisted-addon-service"
+              "$ref": "#/definitions/whitelisted-add-on-service"
             },
             "type": [
               "array"
@@ -14154,302 +14881,27 @@ module PlatformAPI
         },
         {
           "description": "Remove a whitelisted entity",
-          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/whitelisted-addon-services/{(%23%2Fdefinitions%2Fwhitelisted-addon-service%2Fdefinitions%2Fidentity)}",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/whitelisted-addon-services/{(%23%2Fdefinitions%2Fwhitelisted-add-on-service%2Fdefinitions%2Fidentity)}",
           "method": "DELETE",
           "rel": "destroy",
           "targetSchema": {
-            "$ref": "#/definitions/whitelisted-addon-service"
+            "$ref": "#/definitions/whitelisted-add-on-service"
           },
           "title": "Delete"
         }
       ],
       "properties": {
         "added_at": {
-          "$ref": "#/definitions/whitelisted-addon-service/definitions/added_at"
+          "$ref": "#/definitions/whitelisted-add-on-service/definitions/added_at"
         },
         "added_by": {
-          "$ref": "#/definitions/whitelisted-addon-service/definitions/added_by"
+          "$ref": "#/definitions/whitelisted-add-on-service/definitions/added_by"
         },
         "addon_service": {
-          "$ref": "#/definitions/whitelisted-addon-service/definitions/addon_service"
+          "$ref": "#/definitions/whitelisted-add-on-service/definitions/addon_service"
         },
         "id": {
-          "$ref": "#/definitions/whitelisted-addon-service/definitions/id"
-        }
-      }
-    },
-    "sni-endpoint": {
-      "description": "SNI Endpoint is a public address serving a custom SSL cert for HTTPS traffic, using the SNI TLS extension, to a Heroku app. Note: only apps with the `http-sni` and `stable-cname` feature flags or those owned by a user with the `user-http-sni` and `user-stable-cname` feature flags are authorized to use this endpoint.",
-      "$schema": "http://json-schema.org/draft-04/hyper-schema",
-      "title": "Heroku Platform API - SNI Endpoint",
-      "stability": "prototype",
-      "strictProperties": true,
-      "type": [
-        "object"
-      ],
-      "definitions": {
-        "app": {
-          "description": "app receiving the new endpoint",
-          "example": "253c2ffd-192d-4a6f-913e-2f7af25a87ef",
-          "format": "uuid",
-          "readOnly": false,
-          "type": [
-            "string"
-          ]
-        },
-        "ca_signed?": {
-          "readOnly": true,
-          "type": [
-            "boolean"
-          ]
-        },
-        "cert_domains": {
-          "readOnly": true,
-          "type": [
-            "array"
-          ]
-        },
-        "certificate_chain": {
-          "description": "raw contents of the public certificate chain (eg: .crt or .pem file)",
-          "example": "-----BEGIN CERTIFICATE----- ...",
-          "readOnly": false,
-          "type": [
-            "string"
-          ]
-        },
-        "cname": {
-          "description": "canonical name record, the address to point a domain at",
-          "example": "example.herokussl.com",
-          "readOnly": false,
-          "type": [
-            "string"
-          ]
-        },
-        "created_at": {
-          "description": "when endpoint was created",
-          "example": "2012-01-01T12:00:00Z",
-          "format": "date-time",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "expires_at": {
-          "readOnly": true,
-          "format": "date-time",
-          "type": [
-            "string"
-          ]
-        },
-        "id": {
-          "description": "unique identifier of this SNI endpoint",
-          "example": "01234567-89ab-cdef-0123-456789abcdef",
-          "format": "uuid",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "identity": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/sni-endpoint/definitions/id"
-            },
-            {
-              "$ref": "#/definitions/sni-endpoint/definitions/name"
-            }
-          ]
-        },
-        "issuer": {
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "name": {
-          "description": "unique name for SNI endpoint",
-          "example": "example",
-          "pattern": "^[a-z][a-z0-9-]{2,29}$",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "private_key": {
-          "description": "contents of the private key (eg .key file)",
-          "example": "-----BEGIN RSA PRIVATE KEY----- ...",
-          "readOnly": false,
-          "type": [
-            "string"
-          ]
-        },
-        "self_signed?": {
-          "readOnly": true,
-          "type": [
-            "boolean"
-          ]
-        },
-        "starts_at": {
-          "readOnly": true,
-          "format": "date-time",
-          "type": [
-            "string"
-          ]
-        },
-        "subject": {
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "updated_at": {
-          "description": "when SNI endpoint was updated",
-          "example": "2012-01-01T12:00:00Z",
-          "format": "date-time",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        }
-      },
-      "links": [
-        {
-          "description": "Create a new SNI endpoint.",
-          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/sni-endpoints",
-          "method": "POST",
-          "rel": "create",
-          "schema": {
-            "properties": {
-              "app": {
-                "$ref": "#/definitions/sni-endpoint/definitions/app"
-              },
-              "certificate_chain": {
-                "$ref": "#/definitions/sni-endpoint/definitions/certificate_chain"
-              },
-              "private_key": {
-                "$ref": "#/definitions/sni-endpoint/definitions/private_key"
-              }
-            },
-            "required": [
-              "certificate_chain",
-              "private_key"
-            ],
-            "type": [
-              "object"
-            ]
-          },
-          "targetSchema": {
-            "$ref": "#/definitions/sni-endpoint"
-          },
-          "title": "Create"
-        },
-        {
-          "description": "Delete existing SNI endpoint.",
-          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/sni-endpoints/{(%23%2Fdefinitions%2Fsni-endpoint%2Fdefinitions%2Fidentity)}",
-          "method": "DELETE",
-          "rel": "destroy",
-          "targetSchema": {
-            "$ref": "#/definitions/sni-endpoint"
-          },
-          "title": "Delete"
-        },
-        {
-          "description": "Info for existing SNI endpoint.",
-          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/sni-endpoints/{(%23%2Fdefinitions%2Fsni-endpoint%2Fdefinitions%2Fidentity)}",
-          "method": "GET",
-          "rel": "self",
-          "targetSchema": {
-            "$ref": "#/definitions/sni-endpoint"
-          },
-          "title": "Info"
-        },
-        {
-          "description": "List existing SNI endpoints.",
-          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/sni-endpoints",
-          "method": "GET",
-          "rel": "instances",
-          "targetSchema": {
-            "items": {
-              "$ref": "#/definitions/sni-endpoint"
-            },
-            "type": [
-              "array"
-            ]
-          },
-          "title": "List"
-        },
-        {
-          "description": "Update an existing SNI endpoint.",
-          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/sni-endpoints/{(%23%2Fdefinitions%2Fsni-endpoint%2Fdefinitions%2Fidentity)}",
-          "method": "PATCH",
-          "rel": "update",
-          "schema": {
-            "properties": {
-              "certificate_chain": {
-                "$ref": "#/definitions/sni-endpoint/definitions/certificate_chain"
-              },
-              "private_key": {
-                "$ref": "#/definitions/sni-endpoint/definitions/private_key"
-              }
-            },
-            "required": [
-              "certificate_chain",
-              "private_key"
-            ],
-            "type": [
-              "object"
-            ]
-          },
-          "targetSchema": {
-            "$ref": "#/definitions/sni-endpoint"
-          },
-          "title": "Update"
-        }
-      ],
-      "properties": {
-        "certificate_chain": {
-          "$ref": "#/definitions/sni-endpoint/definitions/certificate_chain"
-        },
-        "cname": {
-          "$ref": "#/definitions/sni-endpoint/definitions/cname"
-        },
-        "created_at": {
-          "$ref": "#/definitions/sni-endpoint/definitions/created_at"
-        },
-        "id": {
-          "$ref": "#/definitions/sni-endpoint/definitions/id"
-        },
-        "name": {
-          "$ref": "#/definitions/sni-endpoint/definitions/name"
-        },
-        "updated_at": {
-          "$ref": "#/definitions/sni-endpoint/definitions/updated_at"
-        },
-        "ssl_cert": {
-          "description": "certificate provided by this endpoint",
-          "properties": {
-            "ca_signed?": {
-              "$ref": "#/definitions/sni-endpoint/definitions/ca_signed?"
-            },
-            "cert_domains": {
-              "$ref": "#/definitions/sni-endpoint/definitions/cert_domains"
-            },
-            "expires_at": {
-              "$ref": "#/definitions/sni-endpoint/definitions/expires_at"
-            },
-            "issuer": {
-              "$ref": "#/definitions/sni-endpoint/definitions/issuer"
-            },
-            "self_signed?": {
-              "$ref": "#/definitions/sni-endpoint/definitions/self_signed?"
-            },
-            "starts_at": {
-              "$ref": "#/definitions/sni-endpoint/definitions/starts_at"
-            },
-            "subject": {
-              "$ref": "#/definitions/sni-endpoint/definitions/subject"
-            }
-          }
+          "$ref": "#/definitions/whitelisted-add-on-service/definitions/id"
         }
       }
     }
@@ -14461,26 +14913,32 @@ module PlatformAPI
     "account": {
       "$ref": "#/definitions/account"
     },
-    "addon-action": {
-      "$ref": "#/definitions/addon-action"
+    "add-on-action": {
+      "$ref": "#/definitions/add-on-action"
     },
-    "addon-attachment": {
-      "$ref": "#/definitions/addon-attachment"
+    "add-on-attachment": {
+      "$ref": "#/definitions/add-on-attachment"
     },
-    "addon-config": {
-      "$ref": "#/definitions/addon-config"
+    "add-on-config": {
+      "$ref": "#/definitions/add-on-config"
     },
-    "addon-region-capability": {
-      "$ref": "#/definitions/addon-region-capability"
+    "add-on-plan-action": {
+      "$ref": "#/definitions/add-on-plan-action"
     },
-    "addon-service": {
-      "$ref": "#/definitions/addon-service"
+    "add-on-region-capability": {
+      "$ref": "#/definitions/add-on-region-capability"
     },
-    "addon": {
-      "$ref": "#/definitions/addon"
+    "add-on-service": {
+      "$ref": "#/definitions/add-on-service"
+    },
+    "add-on": {
+      "$ref": "#/definitions/add-on"
     },
     "app-feature": {
       "$ref": "#/definitions/app-feature"
+    },
+    "app-formation-set": {
+      "$ref": "#/definitions/app-formation-set"
     },
     "app-setup": {
       "$ref": "#/definitions/app-setup"
@@ -14512,6 +14970,9 @@ module PlatformAPI
     "domain": {
       "$ref": "#/definitions/domain"
     },
+    "dyno-size": {
+      "$ref": "#/definitions/dyno-size"
+    },
     "dyno": {
       "$ref": "#/definitions/dyno"
     },
@@ -14526,6 +14987,9 @@ module PlatformAPI
     },
     "formation": {
       "$ref": "#/definitions/formation"
+    },
+    "identity-provider": {
+      "$ref": "#/definitions/identity-provider"
     },
     "inbound-ruleset": {
       "$ref": "#/definitions/inbound-ruleset"
@@ -14560,8 +15024,8 @@ module PlatformAPI
     "oauth-token": {
       "$ref": "#/definitions/oauth-token"
     },
-    "organization-addon": {
-      "$ref": "#/definitions/organization-addon"
+    "organization-add-on": {
+      "$ref": "#/definitions/organization-add-on"
     },
     "organization-app-collaborator": {
       "$ref": "#/definitions/organization-app-collaborator"
@@ -14569,14 +15033,17 @@ module PlatformAPI
     "organization-app": {
       "$ref": "#/definitions/organization-app"
     },
+    "organization-feature": {
+      "$ref": "#/definitions/organization-feature"
+    },
+    "organization-invitation": {
+      "$ref": "#/definitions/organization-invitation"
+    },
     "organization-invoice": {
       "$ref": "#/definitions/organization-invoice"
     },
     "organization-member": {
       "$ref": "#/definitions/organization-member"
-    },
-    "organization-payment-method": {
-      "$ref": "#/definitions/organization-payment-method"
     },
     "organization-preferences": {
       "$ref": "#/definitions/organization-preferences"
@@ -14584,20 +15051,11 @@ module PlatformAPI
     "organization": {
       "$ref": "#/definitions/organization"
     },
-    "otp-secret": {
-      "$ref": "#/definitions/otp-secret"
-    },
     "outbound-ruleset": {
       "$ref": "#/definitions/outbound-ruleset"
     },
     "password-reset": {
       "$ref": "#/definitions/password-reset"
-    },
-    "payment-method": {
-      "$ref": "#/definitions/payment-method"
-    },
-    "payment": {
-      "$ref": "#/definitions/payment"
     },
     "organization-app-permission": {
       "$ref": "#/definitions/organization-app-permission"
@@ -14620,9 +15078,6 @@ module PlatformAPI
     "rate-limit": {
       "$ref": "#/definitions/rate-limit"
     },
-    "recovery-code": {
-      "$ref": "#/definitions/recovery-code"
-    },
     "region": {
       "$ref": "#/definitions/region"
     },
@@ -14634,6 +15089,9 @@ module PlatformAPI
     },
     "sms-number": {
       "$ref": "#/definitions/sms-number"
+    },
+    "sni-endpoint": {
+      "$ref": "#/definitions/sni-endpoint"
     },
     "source": {
       "$ref": "#/definitions/source"
@@ -14656,11 +15114,8 @@ module PlatformAPI
     "user-preferences": {
       "$ref": "#/definitions/user-preferences"
     },
-    "whitelisted-addon-service": {
-      "$ref": "#/definitions/whitelisted-addon-service"
-    },
-    "sni-endpoint": {
-      "$ref": "#/definitions/sni-endpoint"
+    "whitelisted-add-on-service": {
+      "$ref": "#/definitions/whitelisted-add-on-service"
     }
   },
   "description": "The platform API empowers developers to automate, extend and combine Heroku with other services.",

--- a/schema.json
+++ b/schema.json
@@ -215,6 +215,14 @@
             "string"
           ]
         },
+        "federated": {
+          "description": "whether the user is federated and belongs to an Identity Provider",
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
         "id": {
           "description": "unique identifier of an account",
           "example": "01234567-89ab-cdef-0123-456789abcdef",
@@ -254,14 +262,6 @@
           "type": [
             "string",
             "null"
-          ]
-        },
-        "new_password": {
-          "description": "the new password for the account when changing the password",
-          "example": "newpassword",
-          "readOnly": true,
-          "type": [
-            "string"
           ]
         },
         "password": {
@@ -365,9 +365,6 @@
               },
               "name": {
                 "$ref": "#/definitions/account/definitions/name"
-              },
-              "password": {
-                "$ref": "#/definitions/account/definitions/password"
               }
             },
             "type": [
@@ -378,57 +375,6 @@
             "$ref": "#/definitions/account"
           },
           "title": "Update"
-        },
-        {
-          "description": "Change Email for account.",
-          "href": "/account",
-          "method": "PATCH",
-          "rel": "update",
-          "schema": {
-            "properties": {
-              "email": {
-                "$ref": "#/definitions/account/definitions/email"
-              },
-              "password": {
-                "$ref": "#/definitions/account/definitions/password"
-              }
-            },
-            "required": [
-              "password",
-              "email"
-            ],
-            "type": [
-              "object"
-            ]
-          },
-          "title": "Change Email"
-        },
-        {
-          "description": "Change Password for account.",
-          "href": "/account",
-          "method": "PATCH",
-          "rel": "update",
-          "schema": {
-            "properties": {
-              "new_password": {
-                "$ref": "#/definitions/account/definitions/new_password"
-              },
-              "password": {
-                "$ref": "#/definitions/account/definitions/password"
-              }
-            },
-            "required": [
-              "new_password",
-              "password"
-            ],
-            "type": [
-              "object"
-            ]
-          },
-          "targetSchema": {
-            "$ref": "#/definitions/account"
-          },
-          "title": "Change Password"
         },
         {
           "description": "Delete account. Note that this action cannot be undone.",
@@ -465,9 +411,6 @@
               },
               "name": {
                 "$ref": "#/definitions/account/definitions/name"
-              },
-              "password": {
-                "$ref": "#/definitions/account/definitions/password"
               }
             },
             "type": [
@@ -478,57 +421,6 @@
             "$ref": "#/definitions/account"
           },
           "title": "Update"
-        },
-        {
-          "description": "Change Email for account.",
-          "href": "/users/{(%23%2Fdefinitions%2Faccount%2Fdefinitions%2Fidentity)}",
-          "method": "PATCH",
-          "rel": "update",
-          "schema": {
-            "properties": {
-              "email": {
-                "$ref": "#/definitions/account/definitions/email"
-              },
-              "password": {
-                "$ref": "#/definitions/account/definitions/password"
-              }
-            },
-            "required": [
-              "password",
-              "email"
-            ],
-            "type": [
-              "object"
-            ]
-          },
-          "title": "Change Email"
-        },
-        {
-          "description": "Change Password for account.",
-          "href": "/users/{(%23%2Fdefinitions%2Faccount%2Fdefinitions%2Fidentity)}",
-          "method": "PATCH",
-          "rel": "update",
-          "schema": {
-            "properties": {
-              "new_password": {
-                "$ref": "#/definitions/account/definitions/new_password"
-              },
-              "password": {
-                "$ref": "#/definitions/account/definitions/password"
-              }
-            },
-            "required": [
-              "new_password",
-              "password"
-            ],
-            "type": [
-              "object"
-            ]
-          },
-          "targetSchema": {
-            "$ref": "#/definitions/account"
-          },
-          "title": "Change Password"
         },
         {
           "description": "Delete account. Note that this action cannot be undone.",
@@ -554,8 +446,33 @@
         "email": {
           "$ref": "#/definitions/account/definitions/email"
         },
+        "federated": {
+          "$ref": "#/definitions/account/definitions/federated"
+        },
         "id": {
           "$ref": "#/definitions/account/definitions/id"
+        },
+        "identity_provider": {
+          "description": "Identity Provider details for federated users.",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/identity-provider/definitions/id"
+            },
+            "organization": {
+              "type": [
+                "object"
+              ],
+              "properties": {
+                "name": {
+                  "$ref": "#/definitions/organization/definitions/name"
+                }
+              }
+            }
+          },
+          "type": [
+            "object",
+            "null"
+          ]
         },
         "last_login": {
           "$ref": "#/definitions/account/definitions/last_login"
@@ -599,8 +516,8 @@
         }
       }
     },
-    "addon-action": {
-      "description": "Add-on Actions are Provider functionality for specific add-on installations",
+    "add-on-action": {
+      "description": "Add-on Actions are lifecycle operations for add-on provisioning and deprovisioning. They allow whitelisted add-on providers to (de)provision add-ons in the background and then report back when (de)provisioning is complete.",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "stability": "development",
       "strictProperties": true,
@@ -609,70 +526,33 @@
         "object"
       ],
       "definitions": {
-        "id": {
-          "description": "a unique identifier",
-          "example": "01234567-89ab-cdef-0123-456789abcdef",
-          "format": "uuid",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "identity": {
-          "$ref": "#/definitions/addon-action/definitions/id"
-        },
-        "label": {
-          "description": "the display text shown in Dashboard",
-          "example": "Example",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "action": {
-          "description": "identifier of the action to take that is sent via SSO",
-          "example": "example",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "url": {
-          "description": "absolute URL to use instead of an action",
-          "example": "http://example.com?resource_id=:resource_id",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "requires_owner": {
-          "description": "if the action requires the user to own the app",
-          "example": true,
-          "readOnly": true,
-          "type": [
-            "boolean"
-          ]
-        }
       },
-      "properties": {
-        "id": {
-          "$ref": "#/definitions/addon-action/definitions/id"
+      "links": [
+        {
+          "description": "Mark an add-on as provisioned for use.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/actions/provision",
+          "method": "POST",
+          "rel": "create",
+          "targetSchema": {
+            "$ref": "#/definitions/add-on"
+          },
+          "title": "Create - Provision"
         },
-        "label": {
-          "$ref": "#/definitions/addon-action/definitions/label"
-        },
-        "action": {
-          "$ref": "#/definitions/addon-action/definitions/action"
-        },
-        "url": {
-          "$ref": "#/definitions/addon-action/definitions/url"
-        },
-        "requires_owner": {
-          "$ref": "#/definitions/addon-action/definitions/requires_owner"
+        {
+          "description": "Mark an add-on as deprovisioned.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/actions/deprovision",
+          "method": "POST",
+          "rel": "create",
+          "targetSchema": {
+            "$ref": "#/definitions/add-on"
+          },
+          "title": "Create - Deprovision"
         }
+      ],
+      "properties": {
       }
     },
-    "addon-attachment": {
+    "add-on-attachment": {
       "description": "An add-on attachment represents a connection between an app and an add-on that it has been given access to.",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "stability": "prototype",
@@ -712,17 +592,17 @@
         "identity": {
           "anyOf": [
             {
-              "$ref": "#/definitions/addon-attachment/definitions/id"
+              "$ref": "#/definitions/add-on-attachment/definitions/id"
             }
           ]
         },
         "scopedIdentity": {
           "anyOf": [
             {
-              "$ref": "#/definitions/addon-attachment/definitions/id"
+              "$ref": "#/definitions/add-on-attachment/definitions/id"
             },
             {
-              "$ref": "#/definitions/addon-attachment/definitions/name"
+              "$ref": "#/definitions/add-on-attachment/definitions/name"
             }
           ]
         },
@@ -763,16 +643,16 @@
           "schema": {
             "properties": {
               "addon": {
-                "$ref": "#/definitions/addon/definitions/identity"
+                "$ref": "#/definitions/add-on/definitions/identity"
               },
               "app": {
                 "$ref": "#/definitions/app/definitions/identity"
               },
               "force": {
-                "$ref": "#/definitions/addon-attachment/definitions/force"
+                "$ref": "#/definitions/add-on-attachment/definitions/force"
               },
               "name": {
-                "$ref": "#/definitions/addon-attachment/definitions/name"
+                "$ref": "#/definitions/add-on-attachment/definitions/name"
               }
             },
             "required": [
@@ -784,27 +664,27 @@
             ]
           },
           "targetSchema": {
-            "$ref": "#/definitions/addon-attachment"
+            "$ref": "#/definitions/add-on-attachment"
           },
           "title": "Create"
         },
         {
           "description": "Delete an existing add-on attachment.",
-          "href": "/addon-attachments/{(%23%2Fdefinitions%2Faddon-attachment%2Fdefinitions%2Fidentity)}",
+          "href": "/addon-attachments/{(%23%2Fdefinitions%2Fadd-on-attachment%2Fdefinitions%2Fidentity)}",
           "method": "DELETE",
           "rel": "destroy",
           "targetSchema": {
-            "$ref": "#/definitions/addon-attachment"
+            "$ref": "#/definitions/add-on-attachment"
           },
           "title": "Delete"
         },
         {
           "description": "Info for existing add-on attachment.",
-          "href": "/addon-attachments/{(%23%2Fdefinitions%2Faddon-attachment%2Fdefinitions%2Fidentity)}",
+          "href": "/addon-attachments/{(%23%2Fdefinitions%2Fadd-on-attachment%2Fdefinitions%2Fidentity)}",
           "method": "GET",
           "rel": "self",
           "targetSchema": {
-            "$ref": "#/definitions/addon-attachment"
+            "$ref": "#/definitions/add-on-attachment"
           },
           "title": "Info"
         },
@@ -815,7 +695,7 @@
           "rel": "instances",
           "targetSchema": {
             "items": {
-              "$ref": "#/definitions/addon-attachment"
+              "$ref": "#/definitions/add-on-attachment"
             },
             "type": [
               "array"
@@ -825,12 +705,12 @@
         },
         {
           "description": "List existing add-on attachments for an add-on.",
-          "href": "/addons/{(%23%2Fdefinitions%2Faddon%2Fdefinitions%2Fidentity)}/addon-attachments",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/addon-attachments",
           "method": "GET",
           "rel": "instances",
           "targetSchema": {
             "items": {
-              "$ref": "#/definitions/addon-attachment"
+              "$ref": "#/definitions/add-on-attachment"
             },
             "type": [
               "array"
@@ -845,7 +725,7 @@
           "rel": "instances",
           "targetSchema": {
             "items": {
-              "$ref": "#/definitions/addon-attachment"
+              "$ref": "#/definitions/add-on-attachment"
             },
             "type": [
               "array"
@@ -855,11 +735,11 @@
         },
         {
           "description": "Info for existing add-on attachment for an app.",
-          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/addon-attachments/{(%23%2Fdefinitions%2Faddon-attachment%2Fdefinitions%2FscopedIdentity)}",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/addon-attachments/{(%23%2Fdefinitions%2Fadd-on-attachment%2Fdefinitions%2FscopedIdentity)}",
           "method": "GET",
           "rel": "self",
           "targetSchema": {
-            "$ref": "#/definitions/addon-attachment"
+            "$ref": "#/definitions/add-on-attachment"
           },
           "title": "Info by App"
         }
@@ -869,10 +749,10 @@
           "description": "identity of add-on",
           "properties": {
             "id": {
-              "$ref": "#/definitions/addon/definitions/id"
+              "$ref": "#/definitions/add-on/definitions/id"
             },
             "name": {
-              "$ref": "#/definitions/addon/definitions/name"
+              "$ref": "#/definitions/add-on/definitions/name"
             },
             "app": {
               "description": "billing application associated with this add-on",
@@ -931,23 +811,23 @@
           ]
         },
         "created_at": {
-          "$ref": "#/definitions/addon-attachment/definitions/created_at"
+          "$ref": "#/definitions/add-on-attachment/definitions/created_at"
         },
         "id": {
-          "$ref": "#/definitions/addon-attachment/definitions/id"
+          "$ref": "#/definitions/add-on-attachment/definitions/id"
         },
         "name": {
-          "$ref": "#/definitions/addon-attachment/definitions/name"
+          "$ref": "#/definitions/add-on-attachment/definitions/name"
         },
         "updated_at": {
-          "$ref": "#/definitions/addon-attachment/definitions/updated_at"
+          "$ref": "#/definitions/add-on-attachment/definitions/updated_at"
         },
         "web_url": {
-          "$ref": "#/definitions/addon-attachment/definitions/web_url"
+          "$ref": "#/definitions/add-on-attachment/definitions/web_url"
         }
       }
     },
-    "addon-config": {
+    "add-on-config": {
       "description": "Configuration of an Add-on",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "stability": "development",
@@ -960,7 +840,7 @@
         "identity": {
           "anyOf": [
             {
-              "$ref": "#/definitions/addon-config/definitions/name"
+              "$ref": "#/definitions/add-on-config/definitions/name"
             }
           ]
         },
@@ -982,13 +862,13 @@
       },
       "links": [
         {
-          "description": "Get an add-on's config",
-          "href": "/addons/{(%23%2Fdefinitions%2Faddon%2Fdefinitions%2Fidentity)}/config",
+          "description": "Get an add-on's config. Accessible by customers with access and by the add-on partner providing this add-on.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/config",
           "method": "GET",
           "rel": "instances",
           "targetSchema": {
             "items": {
-              "$ref": "#/definitions/addon-config"
+              "$ref": "#/definitions/add-on-config"
             },
             "type": [
               "array"
@@ -997,15 +877,15 @@
           "title": "List"
         },
         {
-          "description": "Update an add-on's config.",
-          "href": "/addons/{(%23%2Fdefinitions%2Faddon%2Fdefinitions%2Fidentity)}/config",
+          "description": "Update an add-on's config. Can only be accessed by the add-on partner providing this add-on.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/config",
           "method": "PATCH",
           "rel": "update",
           "schema": {
             "properties": {
               "config": {
                 "items": {
-                  "$ref": "#/definitions/addon-config"
+                  "$ref": "#/definitions/add-on-config"
                 },
                 "type": [
                   "array"
@@ -1018,7 +898,7 @@
           },
           "targetSchema": {
             "items": {
-              "$ref": "#/definitions/addon-config"
+              "$ref": "#/definitions/add-on-config"
             }
           },
           "title": "Update"
@@ -1026,14 +906,87 @@
       ],
       "properties": {
         "name": {
-          "$ref": "#/definitions/addon-config/definitions/name"
+          "$ref": "#/definitions/add-on-config/definitions/name"
         },
         "value": {
-          "$ref": "#/definitions/addon-config/definitions/value"
+          "$ref": "#/definitions/add-on-config/definitions/value"
         }
       }
     },
-    "addon-region-capability": {
+    "add-on-plan-action": {
+      "description": "Add-on Plan Actions are Provider functionality for specific add-on installations",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "development",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Add-on Plan Action",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "id": {
+          "description": "a unique identifier",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "$ref": "#/definitions/add-on-plan-action/definitions/id"
+        },
+        "label": {
+          "description": "the display text shown in Dashboard",
+          "example": "Example",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "action": {
+          "description": "identifier of the action to take that is sent via SSO",
+          "example": "example",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "url": {
+          "description": "absolute URL to use instead of an action",
+          "example": "http://example.com?resource_id=:resource_id",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "requires_owner": {
+          "description": "if the action requires the user to own the app",
+          "example": true,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        }
+      },
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/add-on-plan-action/definitions/id"
+        },
+        "label": {
+          "$ref": "#/definitions/add-on-plan-action/definitions/label"
+        },
+        "action": {
+          "$ref": "#/definitions/add-on-plan-action/definitions/action"
+        },
+        "url": {
+          "$ref": "#/definitions/add-on-plan-action/definitions/url"
+        },
+        "requires_owner": {
+          "$ref": "#/definitions/add-on-plan-action/definitions/requires_owner"
+        }
+      }
+    },
+    "add-on-region-capability": {
       "description": "Add-on region capabilities represent the relationship between an Add-on Service and a specific Region. Only Beta and GA add-ons are returned by these endpoints.",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "stability": "production",
@@ -1044,7 +997,7 @@
       ],
       "definitions": {
         "id": {
-          "description": "unique identifier of this addon-region-capability",
+          "description": "unique identifier of this add-on-region-capability",
           "example": "01234567-89ab-cdef-0123-456789abcdef",
           "format": "uuid",
           "readOnly": true,
@@ -1060,7 +1013,7 @@
           ]
         },
         "identity": {
-          "$ref": "#/definitions/addon-region-capability/definitions/id"
+          "$ref": "#/definitions/add-on-region-capability/definitions/id"
         }
       },
       "links": [
@@ -1071,7 +1024,7 @@
           "rel": "instances",
           "targetSchema": {
             "items": {
-              "$ref": "#/definitions/addon-region-capability"
+              "$ref": "#/definitions/add-on-region-capability"
             },
             "type": [
               "array"
@@ -1080,13 +1033,13 @@
           "title": "List"
         },
         {
-          "description": "List existing add-on region capabilities for an addon-service",
-          "href": "/addon-services/{(%23%2Fdefinitions%2Faddon-service%2Fdefinitions%2Fidentity)}/region-capabilities",
+          "description": "List existing add-on region capabilities for an add-on-service",
+          "href": "/addon-services/{(%23%2Fdefinitions%2Fadd-on-service%2Fdefinitions%2Fidentity)}/region-capabilities",
           "method": "GET",
           "rel": "instances",
           "targetSchema": {
             "items": {
-              "$ref": "#/definitions/addon-region-capability"
+              "$ref": "#/definitions/add-on-region-capability"
             },
             "type": [
               "array"
@@ -1101,7 +1054,7 @@
           "rel": "instances",
           "targetSchema": {
             "items": {
-              "$ref": "#/definitions/addon-region-capability"
+              "$ref": "#/definitions/add-on-region-capability"
             },
             "type": [
               "array"
@@ -1112,20 +1065,20 @@
       ],
       "properties": {
         "id": {
-          "$ref": "#/definitions/addon-region-capability/definitions/id"
+          "$ref": "#/definitions/add-on-region-capability/definitions/id"
         },
         "supports_private_networking": {
-          "$ref": "#/definitions/addon-region-capability/definitions/supports_private_networking"
+          "$ref": "#/definitions/add-on-region-capability/definitions/supports_private_networking"
         },
         "addon_service": {
-          "$ref": "#/definitions/addon-service"
+          "$ref": "#/definitions/add-on-service"
         },
         "region": {
           "$ref": "#/definitions/region"
         }
       }
     },
-    "addon-service": {
+    "add-on-service": {
       "description": "Add-on services represent add-ons that may be provisioned for apps. Endpoints under add-on services can be accessed without authentication.",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "stability": "production",
@@ -1145,7 +1098,7 @@
           ]
         },
         "created_at": {
-          "description": "when addon-service was created",
+          "description": "when add-on-service was created",
           "example": "2012-01-01T12:00:00Z",
           "format": "date-time",
           "readOnly": true,
@@ -1154,7 +1107,7 @@
           ]
         },
         "human_name": {
-          "description": "human-readable name of the addon service provider",
+          "description": "human-readable name of the add-on service provider",
           "example": "Heroku Postgres",
           "readOnly": true,
           "type": [
@@ -1162,7 +1115,7 @@
           ]
         },
         "id": {
-          "description": "unique identifier of this addon-service",
+          "description": "unique identifier of this add-on-service",
           "example": "01234567-89ab-cdef-0123-456789abcdef",
           "format": "uuid",
           "readOnly": true,
@@ -1173,15 +1126,15 @@
         "identity": {
           "anyOf": [
             {
-              "$ref": "#/definitions/addon-service/definitions/id"
+              "$ref": "#/definitions/add-on-service/definitions/id"
             },
             {
-              "$ref": "#/definitions/addon-service/definitions/name"
+              "$ref": "#/definitions/add-on-service/definitions/name"
             }
           ]
         },
         "name": {
-          "description": "unique name of this addon-service",
+          "description": "unique name of this add-on-service",
           "example": "heroku-postgresql",
           "readOnly": true,
           "type": [
@@ -1221,7 +1174,7 @@
           ]
         },
         "updated_at": {
-          "description": "when addon-service was updated",
+          "description": "when add-on-service was updated",
           "example": "2012-01-01T12:00:00Z",
           "format": "date-time",
           "readOnly": true,
@@ -1232,23 +1185,23 @@
       },
       "links": [
         {
-          "description": "Info for existing addon-service.",
-          "href": "/addon-services/{(%23%2Fdefinitions%2Faddon-service%2Fdefinitions%2Fidentity)}",
+          "description": "Info for existing add-on-service.",
+          "href": "/addon-services/{(%23%2Fdefinitions%2Fadd-on-service%2Fdefinitions%2Fidentity)}",
           "method": "GET",
           "rel": "self",
           "targetSchema": {
-            "$ref": "#/definitions/addon-service"
+            "$ref": "#/definitions/add-on-service"
           },
           "title": "Info"
         },
         {
-          "description": "List existing addon-services.",
+          "description": "List existing add-on-services.",
           "href": "/addon-services",
           "method": "GET",
           "rel": "instances",
           "targetSchema": {
             "items": {
-              "$ref": "#/definitions/addon-service"
+              "$ref": "#/definitions/add-on-service"
             },
             "type": [
               "array"
@@ -1259,35 +1212,35 @@
       ],
       "properties": {
         "cli_plugin_name": {
-          "$ref": "#/definitions/addon-service/definitions/cli_plugin_name"
+          "$ref": "#/definitions/add-on-service/definitions/cli_plugin_name"
         },
         "created_at": {
-          "$ref": "#/definitions/addon-service/definitions/created_at"
+          "$ref": "#/definitions/add-on-service/definitions/created_at"
         },
         "human_name": {
-          "$ref": "#/definitions/addon-service/definitions/human_name"
+          "$ref": "#/definitions/add-on-service/definitions/human_name"
         },
         "id": {
-          "$ref": "#/definitions/addon-service/definitions/id"
+          "$ref": "#/definitions/add-on-service/definitions/id"
         },
         "name": {
-          "$ref": "#/definitions/addon-service/definitions/name"
+          "$ref": "#/definitions/add-on-service/definitions/name"
         },
         "state": {
-          "$ref": "#/definitions/addon-service/definitions/state"
+          "$ref": "#/definitions/add-on-service/definitions/state"
         },
         "supports_multiple_installations": {
-          "$ref": "#/definitions/addon-service/definitions/supports_multiple_installations"
+          "$ref": "#/definitions/add-on-service/definitions/supports_multiple_installations"
         },
         "supports_sharing": {
-          "$ref": "#/definitions/addon-service/definitions/supports_sharing"
+          "$ref": "#/definitions/add-on-service/definitions/supports_sharing"
         },
         "updated_at": {
-          "$ref": "#/definitions/addon-service/definitions/updated_at"
+          "$ref": "#/definitions/add-on-service/definitions/updated_at"
         }
       }
     },
-    "addon": {
+    "add-on": {
       "description": "Add-ons represent add-ons that have been provisioned and attached to one or more apps.",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "stability": "production",
@@ -1310,19 +1263,19 @@
           "readOnly": true,
           "properties": {
             "id": {
-              "$ref": "#/definitions/addon-action/definitions/id"
+              "$ref": "#/definitions/add-on-plan-action/definitions/id"
             },
             "label": {
-              "$ref": "#/definitions/addon-action/definitions/label"
+              "$ref": "#/definitions/add-on-plan-action/definitions/label"
             },
             "action": {
-              "$ref": "#/definitions/addon-action/definitions/action"
+              "$ref": "#/definitions/add-on-plan-action/definitions/action"
             },
             "url": {
-              "$ref": "#/definitions/addon-action/definitions/url"
+              "$ref": "#/definitions/add-on-plan-action/definitions/url"
             },
             "requires_owner": {
-              "$ref": "#/definitions/addon-action/definitions/requires_owner"
+              "$ref": "#/definitions/add-on-plan-action/definitions/requires_owner"
             }
           }
         },
@@ -1363,10 +1316,10 @@
         "identity": {
           "anyOf": [
             {
-              "$ref": "#/definitions/addon/definitions/id"
+              "$ref": "#/definitions/add-on/definitions/id"
             },
             {
-              "$ref": "#/definitions/addon/definitions/name"
+              "$ref": "#/definitions/add-on/definitions/name"
             }
           ]
         },
@@ -1382,6 +1335,19 @@
         "provider_id": {
           "description": "id of this add-on with its provider",
           "example": "abcd1234",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "state": {
+          "description": "state in the add-on's lifecycle",
+          "enum": [
+            "provisioning",
+            "provisioned",
+            "deprovisioned"
+          ],
+          "example": "provisioned",
           "readOnly": true,
           "type": [
             "string"
@@ -1421,7 +1387,7 @@
                   "name": "DATABASE_FOLLOWER"
                 },
                 "name": {
-                  "$ref": "#/definitions/addon-attachment/definitions/name"
+                  "$ref": "#/definitions/add-on-attachment/definitions/name"
                 },
                 "type": [
                   "object"
@@ -1456,27 +1422,27 @@
             ]
           },
           "targetSchema": {
-            "$ref": "#/definitions/addon"
+            "$ref": "#/definitions/add-on"
           },
           "title": "Create"
         },
         {
           "description": "Delete an existing add-on.",
-          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/addons/{(%23%2Fdefinitions%2Faddon%2Fdefinitions%2Fidentity)}",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}",
           "method": "DELETE",
           "rel": "destroy",
           "targetSchema": {
-            "$ref": "#/definitions/addon"
+            "$ref": "#/definitions/add-on"
           },
           "title": "Delete"
         },
         {
           "description": "Info for an existing add-on.",
-          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/addons/{(%23%2Fdefinitions%2Faddon%2Fdefinitions%2Fidentity)}",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}",
           "method": "GET",
           "rel": "self",
           "targetSchema": {
-            "$ref": "#/definitions/addon"
+            "$ref": "#/definitions/add-on"
           },
           "title": "Info"
         },
@@ -1487,7 +1453,7 @@
           "rel": "instances",
           "targetSchema": {
             "items": {
-              "$ref": "#/definitions/addon"
+              "$ref": "#/definitions/add-on"
             },
             "type": [
               "array"
@@ -1497,11 +1463,11 @@
         },
         {
           "description": "Info for an existing add-on.",
-          "href": "/addons/{(%23%2Fdefinitions%2Faddon%2Fdefinitions%2Fidentity)}",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}",
           "method": "GET",
           "rel": "self",
           "targetSchema": {
-            "$ref": "#/definitions/addon"
+            "$ref": "#/definitions/add-on"
           },
           "title": "Info"
         },
@@ -1512,7 +1478,7 @@
           "rel": "instances",
           "targetSchema": {
             "items": {
-              "$ref": "#/definitions/addon"
+              "$ref": "#/definitions/add-on"
             },
             "type": [
               "array"
@@ -1527,7 +1493,7 @@
           "rel": "instances",
           "targetSchema": {
             "items": {
-              "$ref": "#/definitions/addon"
+              "$ref": "#/definitions/add-on"
             },
             "type": [
               "array"
@@ -1537,7 +1503,7 @@
         },
         {
           "description": "Change add-on plan. Some add-ons may not support changing plans. In that case, an error will be returned.",
-          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/addons/{(%23%2Fdefinitions%2Faddon%2Fdefinitions%2Fidentity)}",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}",
           "method": "PATCH",
           "rel": "update",
           "schema": {
@@ -1558,16 +1524,16 @@
       ],
       "properties": {
         "actions": {
-          "$ref": "#/definitions/addon/definitions/actions"
+          "$ref": "#/definitions/add-on/definitions/actions"
         },
         "addon_service": {
           "description": "identity of add-on service",
           "properties": {
             "id": {
-              "$ref": "#/definitions/addon-service/definitions/id"
+              "$ref": "#/definitions/add-on-service/definitions/id"
             },
             "name": {
-              "$ref": "#/definitions/addon-service/definitions/name"
+              "$ref": "#/definitions/add-on-service/definitions/name"
             }
           },
           "strictProperties": true,
@@ -1591,16 +1557,16 @@
           "strictProperties": true
         },
         "config_vars": {
-          "$ref": "#/definitions/addon/definitions/config_vars"
+          "$ref": "#/definitions/add-on/definitions/config_vars"
         },
         "created_at": {
-          "$ref": "#/definitions/addon/definitions/created_at"
+          "$ref": "#/definitions/add-on/definitions/created_at"
         },
         "id": {
-          "$ref": "#/definitions/addon/definitions/id"
+          "$ref": "#/definitions/add-on/definitions/id"
         },
         "name": {
-          "$ref": "#/definitions/addon/definitions/name"
+          "$ref": "#/definitions/add-on/definitions/name"
         },
         "plan": {
           "description": "identity of add-on plan",
@@ -1618,13 +1584,16 @@
           ]
         },
         "provider_id": {
-          "$ref": "#/definitions/addon/definitions/provider_id"
+          "$ref": "#/definitions/add-on/definitions/provider_id"
+        },
+        "state": {
+          "$ref": "#/definitions/add-on/definitions/state"
         },
         "updated_at": {
-          "$ref": "#/definitions/addon/definitions/updated_at"
+          "$ref": "#/definitions/add-on/definitions/updated_at"
         },
         "web_url": {
-          "$ref": "#/definitions/addon/definitions/web_url"
+          "$ref": "#/definitions/add-on/definitions/web_url"
         }
       }
     },
@@ -1793,6 +1762,64 @@
         }
       }
     },
+    "app-formation-set": {
+      "description": "App formation set describes the combination of process types with their quantities and sizes as well as application process tier",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "development",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Application Formation Set",
+      "type": [
+        "object"
+      ],
+      "properties": {
+        "description": {
+          "description": "a string representation of the formation set",
+          "example": "web@2:Standard-2X worker@3:Performance-M",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "process_tier": {
+          "description": "application process tier",
+          "enum": [
+            "production",
+            "traditional",
+            "free",
+            "hobby",
+            "private"
+          ],
+          "example": "production",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "app": {
+          "description": "app being described by the formation-set",
+          "properties": {
+            "name": {
+              "$ref": "#/definitions/app/definitions/name"
+            },
+            "id": {
+              "$ref": "#/definitions/app/definitions/id"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "updated_at": {
+          "description": "last time fomation-set was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      }
+    },
     "app-setup": {
       "description": "An app setup represents an app on Heroku that is setup using an environment, addons, and scripts described in an app.json manifest file.",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
@@ -1817,6 +1844,21 @@
             {
               "$ref": "#/definitions/app-setup/definitions/id"
             }
+          ]
+        },
+        "buildpack_override": {
+          "description": "a buildpack override",
+          "properties": {
+            "url": {
+              "description": "location of the buildpack",
+              "example": "https://example.com/buildpack.tgz",
+              "type": [
+                "string"
+              ]
+            }
+          },
+          "type": [
+            "object"
           ]
         },
         "created_at": {
@@ -1881,6 +1923,58 @@
           },
           "type": [
             "array"
+          ]
+        },
+        "overrides": {
+          "description": "overrides of keys in the app.json manifest file",
+          "example": {
+            "buildpacks": [
+              {
+                "url": "https://example.com/buildpack.tgz"
+              }
+            ],
+            "env": {
+              "FOO": "bar",
+              "BAZ": "qux"
+            }
+          },
+          "properties": {
+            "buildpacks": {
+              "description": "overrides the buildpacks specified in the app.json manifest file",
+              "example": [
+                {
+                  "url": "https://example.com/buildpack.tgz"
+                }
+              ],
+              "items": {
+                "$ref": "#/definitions/app-setup/definitions/buildpack_override"
+              },
+              "type": [
+                "array"
+              ]
+            },
+            "env": {
+              "description": "overrides of the env specified in the app.json manifest file",
+              "example": {
+                "FOO": "bar",
+                "BAZ": "qux"
+              },
+              "readOnly": true,
+              "additionalProperties": false,
+              "patternProperties": {
+                "^\\w+$": {
+                  "type": [
+                    "string"
+                  ]
+                }
+              },
+              "type": [
+                "object"
+              ]
+            }
+          },
+          "type": [
+            "object"
           ]
         },
         "postdeploy": {
@@ -2003,6 +2097,9 @@
                   "region": {
                     "$ref": "#/definitions/region/definitions/name"
                   },
+                  "space": {
+                    "$ref": "#/definitions/space/definitions/name"
+                  },
                   "stack": {
                     "$ref": "#/definitions/stack/definitions/name"
                   }
@@ -2046,37 +2143,7 @@
                 ]
               },
               "overrides": {
-                "description": "overrides of keys in the app.json manifest file",
-                "example": {
-                  "env": {
-                    "FOO": "bar",
-                    "BAZ": "qux"
-                  }
-                },
-                "properties": {
-                  "env": {
-                    "description": "overrides of the env specified in the app.json manifest file",
-                    "example": {
-                      "FOO": "bar",
-                      "BAZ": "qux"
-                    },
-                    "readOnly": true,
-                    "additionalProperties": false,
-                    "patternProperties": {
-                      "^\\w+$": {
-                        "type": [
-                          "string"
-                        ]
-                      }
-                    },
-                    "type": [
-                      "object"
-                    ]
-                  }
-                },
-                "type": [
-                  "object"
-                ]
+                "$ref": "#/definitions/app-setup/definitions/overrides"
               }
             }
           },
@@ -2448,6 +2515,15 @@
           "type": [
             "string"
           ]
+        },
+        "acm": {
+          "description": "ACM status of this app",
+          "default": false,
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
         }
       },
       "links": [
@@ -2663,6 +2739,9 @@
             },
             "name": {
               "$ref": "#/definitions/space/definitions/name"
+            },
+            "shield": {
+              "$ref": "#/definitions/space/definitions/shield"
             }
           },
           "type": [
@@ -3376,6 +3455,9 @@
             "email": {
               "$ref": "#/definitions/account/definitions/email"
             },
+            "federated": {
+              "$ref": "#/definitions/account/definitions/federated"
+            },
             "id": {
               "$ref": "#/definitions/account/definitions/id"
             }
@@ -3426,7 +3508,17 @@
           "targetSchema": {
             "$ref": "#/definitions/config-var/definitions/config_vars"
           },
-          "title": "Info"
+          "title": "Info for App"
+        },
+        {
+          "description": "Get config-vars for a release.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/releases/{(%23%2Fdefinitions%2Frelease%2Fdefinitions%2Fidentity)}/config-vars",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/config-var/definitions/config_vars"
+          },
+          "title": "Info for App Release"
         },
         {
           "description": "Update config-vars for app. You can update existing config-vars by setting them again, and remove by setting it to `null`.",
@@ -3807,6 +3899,164 @@
         }
       }
     },
+    "dyno-size": {
+      "description": "Dyno sizes are the values and details of sizes that can be assigned to dynos. This information can also be found at : [https://devcenter.heroku.com/articles/dyno-types](https://devcenter.heroku.com/articles/dyno-types).",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "prototype",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Dyno Size",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "compute": {
+          "description": "minimum vCPUs, non-dedicated may get more depending on load",
+          "example": 1,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "dedicated": {
+          "description": "whether this dyno will be dedicated to one user",
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of this dyno size",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/dyno-size/definitions/id"
+            },
+            {
+              "$ref": "#/definitions/dyno-size/definitions/name"
+            }
+          ]
+        },
+        "memory": {
+          "description": "amount of RAM in GB",
+          "example": 0.5,
+          "readOnly": true,
+          "type": [
+            "number"
+          ]
+        },
+        "name": {
+          "description": "the name of this dyno-size",
+          "example": "free",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "cost": {
+          "description": "price information for this dyno size",
+          "readOnly": true,
+          "type": [
+            "null",
+            "object"
+          ],
+          "definitions": {
+            "cents": {
+              "description": "price in cents per unit time",
+              "example": 0,
+              "readOnly": true,
+              "type": [
+                "integer"
+              ]
+            },
+            "unit": {
+              "description": "unit of price for dyno",
+              "readOnly": true,
+              "example": "month",
+              "type": [
+                "string"
+              ]
+            }
+          }
+        },
+        "dyno_units": {
+          "description": "unit of consumption for Heroku Enterprise customers",
+          "example": 0,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "private_space_only": {
+          "description": "whether this dyno can only be provisioned in a private space",
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Info for existing dyno size.",
+          "href": "/dyno-sizes/{(%23%2Fdefinitions%2Fdyno-size%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/dyno-size"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List existing dyno sizes.",
+          "href": "/dyno-sizes",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/dyno-size"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "compute": {
+          "$ref": "#/definitions/dyno-size/definitions/compute"
+        },
+        "cost": {
+          "$ref": "#/definitions/dyno-size/definitions/cost"
+        },
+        "dedicated": {
+          "$ref": "#/definitions/dyno-size/definitions/dedicated"
+        },
+        "dyno_units": {
+          "$ref": "#/definitions/dyno-size/definitions/dyno_units"
+        },
+        "id": {
+          "$ref": "#/definitions/dyno-size/definitions/id"
+        },
+        "memory": {
+          "$ref": "#/definitions/dyno-size/definitions/memory"
+        },
+        "name": {
+          "$ref": "#/definitions/dyno-size/definitions/name"
+        },
+        "private_space_only": {
+          "$ref": "#/definitions/dyno-size/definitions/private_space_only"
+        }
+      }
+    },
     "dyno": {
       "description": "Dynos encapsulate running processes of an app on Heroku. Detailed information about dyno sizes can be found at: [https://devcenter.heroku.com/articles/dyno-types](https://devcenter.heroku.com/articles/dyno-types).",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
@@ -4005,7 +4255,7 @@
           "title": "Restart"
         },
         {
-          "description": "Restart all dynos",
+          "description": "Restart all dynos.",
           "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/dynos",
           "method": "DELETE",
           "rel": "empty",
@@ -4016,6 +4266,19 @@
             ]
           },
           "title": "Restart all"
+        },
+        {
+          "description": "Stop dyno.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/dynos/{(%23%2Fdefinitions%2Fdyno%2Fdefinitions%2Fidentity)}/actions/stop",
+          "method": "POST",
+          "rel": "empty",
+          "targetSchema": {
+            "additionalPoperties": false,
+            "type": [
+              "object"
+            ]
+          },
+          "title": "Stop"
         },
         {
           "description": "Info for existing dyno.",
@@ -4143,13 +4406,16 @@
               "$ref": "#/definitions/account"
             },
             {
-              "$ref": "#/definitions/addon"
+              "$ref": "#/definitions/add-on"
             },
             {
-              "$ref": "#/definitions/addon-attachment"
+              "$ref": "#/definitions/add-on-attachment"
             },
             {
               "$ref": "#/definitions/app"
+            },
+            {
+              "$ref": "#/definitions/app-formation-set"
             },
             {
               "$ref": "#/definitions/app-setup"
@@ -4174,6 +4440,9 @@
             },
             {
               "$ref": "#/definitions/formation"
+            },
+            {
+              "$ref": "#/definitions/inbound-ruleset"
             },
             {
               "$ref": "#/definitions/organization"
@@ -4230,6 +4499,8 @@
             "dyno",
             "failed-event",
             "formation",
+            "formation-set",
+            "inbound-ruleset",
             "organization",
             "release",
             "space",
@@ -4583,6 +4854,7 @@
           "description": "type of process to maintain",
           "example": "web",
           "readOnly": true,
+          "pattern": "^[-\\w]{1,128}$",
           "type": [
             "string"
           ]
@@ -4741,6 +5013,202 @@
         },
         "updated_at": {
           "$ref": "#/definitions/formation/definitions/updated_at"
+        }
+      }
+    },
+    "identity-provider": {
+      "description": "Identity Providers represent the SAML configuration of an Organization.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Identity Provider",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "certificate": {
+          "description": "raw contents of the public certificate (eg: .crt or .pem file)",
+          "example": "-----BEGIN CERTIFICATE----- ...",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "created_at": {
+          "description": "when provider record was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "entity_id": {
+          "description": "URL identifier provided by the identity provider",
+          "example": "https://customer-domain.idp.com",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of this identity provider",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "slo_target_url": {
+          "description": "single log out URL for this identity provider",
+          "example": "https://example.com/idp/logout",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "sso_target_url": {
+          "description": "single sign on URL for this identity provider",
+          "example": "https://example.com/idp/login",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when the identity provider record was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Get a list of an organization's Identity Providers",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fname)}/identity-providers",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/identity-provider"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "Create an Identity Provider for an organization",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fname)}/identity-providers",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "certificate": {
+                "$ref": "#/definitions/identity-provider/definitions/certificate"
+              },
+              "entity_id": {
+                "$ref": "#/definitions/identity-provider/definitions/entity_id"
+              },
+              "slo_target_url": {
+                "$ref": "#/definitions/identity-provider/definitions/slo_target_url"
+              },
+              "sso_target_url": {
+                "$ref": "#/definitions/identity-provider/definitions/sso_target_url"
+              }
+            },
+            "required": [
+              "certificate",
+              "sso_target_url",
+              "entity_id"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/identity-provider"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Update an organization's Identity Provider",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fname)}/identity-providers/{(%23%2Fdefinitions%2Fidentity-provider%2Fdefinitions%2Fid)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "certificate": {
+                "$ref": "#/definitions/identity-provider/definitions/certificate"
+              },
+              "entity_id": {
+                "$ref": "#/definitions/identity-provider/definitions/entity_id"
+              },
+              "slo_target_url": {
+                "$ref": "#/definitions/identity-provider/definitions/slo_target_url"
+              },
+              "sso_target_url": {
+                "$ref": "#/definitions/identity-provider/definitions/sso_target_url"
+              }
+            },
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/identity-provider"
+          },
+          "title": "Update"
+        },
+        {
+          "description": "Delete an organization's Identity Provider",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fname)}/identity-providers/{(%23%2Fdefinitions%2Fidentity-provider%2Fdefinitions%2Fid)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/identity-provider"
+          },
+          "title": "Delete"
+        }
+      ],
+      "properties": {
+        "certificate": {
+          "$ref": "#/definitions/identity-provider/definitions/certificate"
+        },
+        "created_at": {
+          "$ref": "#/definitions/identity-provider/definitions/created_at"
+        },
+        "entity_id": {
+          "$ref": "#/definitions/identity-provider/definitions/entity_id"
+        },
+        "id": {
+          "$ref": "#/definitions/identity-provider/definitions/id"
+        },
+        "slo_target_url": {
+          "$ref": "#/definitions/identity-provider/definitions/slo_target_url"
+        },
+        "sso_target_url": {
+          "$ref": "#/definitions/identity-provider/definitions/sso_target_url"
+        },
+        "organization": {
+          "description": "organization associated with this identity provider",
+          "properties": {
+            "name": {
+              "$ref": "#/definitions/organization/definitions/name"
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ]
+        },
+        "updated_at": {
+          "$ref": "#/definitions/identity-provider/definitions/updated_at"
         }
       }
     },
@@ -4932,11 +5400,45 @@
             "boolean"
           ]
         },
+        "verification_required": {
+          "description": "if the invitation requires verification",
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
         "token": {
           "description": "Unique identifier of an invitation",
           "example": "01234567-89ab-cdef-0123-456789abcdef",
           "format": "uuid",
           "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "phone_number": {
+          "description": "Phone number to send verification code",
+          "example": "+1 123-123-1234",
+          "type": [
+            "string"
+          ]
+        },
+        "method": {
+          "description": "Transport used to send verification code",
+          "example": "sms",
+          "default": "sms",
+          "type": [
+            "string"
+          ],
+          "enum": [
+            "call",
+            "sms"
+          ]
+        },
+        "verification_code": {
+          "description": "Value used to verify invitation",
+          "example": "123456",
           "type": [
             "string"
           ]
@@ -4949,6 +5451,73 @@
           "method": "GET",
           "rel": "self",
           "title": "Info"
+        },
+        {
+          "description": "Invite a user.",
+          "href": "/invitations",
+          "method": "POST",
+          "rel": "self",
+          "schema": {
+            "properties": {
+              "email": {
+                "$ref": "#/definitions/account/definitions/email"
+              },
+              "name": {
+                "$ref": "#/definitions/account/definitions/name"
+              }
+            },
+            "required": [
+              "email",
+              "name"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Send a verification code for an invitation via SMS/phone call.",
+          "href": "/invitations/{(%23%2Fdefinitions%2Finvitation%2Fdefinitions%2Fidentity)}/actions/send-verification",
+          "method": "POST",
+          "rel": "empty",
+          "schema": {
+            "properties": {
+              "phone_number": {
+                "$ref": "#/definitions/invitation/definitions/phone_number"
+              },
+              "method": {
+                "$ref": "#/definitions/invitation/definitions/method"
+              }
+            },
+            "required": [
+              "phone_number"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "title": "Send Verification Code"
+        },
+        {
+          "description": "Verify an invitation using a verification code.",
+          "href": "/invitations/{(%23%2Fdefinitions%2Finvitation%2Fdefinitions%2Fidentity)}/actions/verify",
+          "method": "POST",
+          "rel": "self",
+          "schema": {
+            "properties": {
+              "verification_code": {
+                "$ref": "#/definitions/invitation/definitions/verification_code"
+              }
+            },
+            "required": [
+              "verification_code"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "title": "Verify"
         },
         {
           "description": "Finalize Invitation and Create Account.",
@@ -4975,34 +5544,13 @@
               "object"
             ]
           },
-          "title": "Finalize Invitation"
-        },
-        {
-          "description": "Invite a user.",
-          "href": "/invitations",
-          "method": "POST",
-          "rel": "self",
-          "schema": {
-            "properties": {
-              "email": {
-                "$ref": "#/definitions/account/definitions/email"
-              },
-              "name": {
-                "$ref": "#/definitions/account/definitions/name"
-              }
-            },
-            "required": [
-              "email",
-              "name"
-            ],
-            "type": [
-              "object"
-            ]
-          },
-          "title": "Invitation"
+          "title": "Finalize"
         }
       ],
       "properties": {
+        "verification_required": {
+          "$ref": "#/definitions/invitation/definitions/verification_required"
+        },
         "created_at": {
           "$ref": "#/definitions/invitation/definitions/created_at"
         },
@@ -5425,39 +5973,6 @@
       },
       "links": [
         {
-          "description": "Create a new key.",
-          "href": "/account/keys",
-          "method": "POST",
-          "rel": "create",
-          "schema": {
-            "properties": {
-              "public_key": {
-                "$ref": "#/definitions/key/definitions/public_key"
-              }
-            },
-            "required": [
-              "public_key"
-            ],
-            "type": [
-              "object"
-            ]
-          },
-          "targetSchema": {
-            "$ref": "#/definitions/key"
-          },
-          "title": "Create"
-        },
-        {
-          "description": "Delete an existing key",
-          "href": "/account/keys/{(%23%2Fdefinitions%2Fkey%2Fdefinitions%2Fidentity)}",
-          "method": "DELETE",
-          "rel": "destroy",
-          "targetSchema": {
-            "$ref": "#/definitions/key"
-          },
-          "title": "Delete"
-        },
-        {
           "description": "Info for existing key.",
           "href": "/account/keys/{(%23%2Fdefinitions%2Fkey%2Fdefinitions%2Fidentity)}",
           "method": "GET",
@@ -5508,7 +6023,7 @@
       }
     },
     "log-drain": {
-      "description": "[Log drains](https://devcenter.heroku.com/articles/log-drains) provide a way to forward your Heroku logs to an external syslog server for long-term archiving. This external service must be configured to receive syslog packets from Heroku, whereupon its URL can be added to an app using this API. Some addons will add a log drain when they are provisioned to an app. These drains can only be removed by removing the add-on.",
+      "description": "[Log drains](https://devcenter.heroku.com/articles/log-drains) provide a way to forward your Heroku logs to an external syslog server for long-term archiving. This external service must be configured to receive syslog packets from Heroku, whereupon its URL can be added to an app using this API. Some add-ons will add a log drain when they are provisioned to an app. These drains can only be removed by removing the add-on.",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "stability": "production",
       "strictProperties": true,
@@ -5518,17 +6033,17 @@
       ],
       "definitions": {
         "addon": {
-          "description": "addon that created the drain",
+          "description": "add-on that created the drain",
           "example": {
             "id": "01234567-89ab-cdef-0123-456789abcdef",
             "name": "singing-swiftly-1242"
           },
           "properties": {
             "id": {
-              "$ref": "#/definitions/addon/definitions/id"
+              "$ref": "#/definitions/add-on/definitions/id"
             },
             "name": {
-              "$ref": "#/definitions/addon/definitions/name"
+              "$ref": "#/definitions/add-on/definitions/name"
             }
           },
           "readOnly": true,
@@ -6560,7 +7075,7 @@
         }
       }
     },
-    "organization-addon": {
+    "organization-add-on": {
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "description": "A list of add-ons the Organization uses across all apps",
       "stability": "production",
@@ -6576,7 +7091,7 @@
           "rel": "instances",
           "targetSchema": {
             "items": {
-              "$ref": "#/definitions/addon"
+              "$ref": "#/definitions/add-on"
             },
             "type": [
               "array"
@@ -6709,6 +7224,9 @@
           "properties": {
             "email": {
               "$ref": "#/definitions/account/definitions/email"
+            },
+            "federated": {
+              "$ref": "#/definitions/account/definitions/federated"
             },
             "id": {
               "$ref": "#/definitions/account/definitions/id"
@@ -7017,6 +7535,332 @@
         }
       }
     },
+    "organization-feature": {
+      "description": "An organization feature represents a feature enabled on an organization account.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "prototype",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Organization Feature",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when organization feature was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "description": {
+          "description": "description of organization feature",
+          "example": "Causes account to example.",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "doc_url": {
+          "description": "documentation URL of organization feature",
+          "example": "http://devcenter.heroku.com/articles/example",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "enabled": {
+          "description": "whether or not account feature has been enabled",
+          "example": true,
+          "readOnly": false,
+          "type": [
+            "boolean"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of organization feature",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/organization-feature/definitions/id"
+            },
+            {
+              "$ref": "#/definitions/organization-feature/definitions/name"
+            }
+          ]
+        },
+        "name": {
+          "description": "unique name of organization feature",
+          "example": "name",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "state": {
+          "description": "state of organization feature",
+          "example": "public",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when organization feature was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Info for an existing account feature.",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/features/{(%23%2Fdefinitions%2Forganization-feature%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/organization-feature"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List existing organization features.",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/features",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/organization-feature"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/account-feature/definitions/created_at"
+        },
+        "description": {
+          "$ref": "#/definitions/account-feature/definitions/description"
+        },
+        "doc_url": {
+          "$ref": "#/definitions/account-feature/definitions/doc_url"
+        },
+        "enabled": {
+          "$ref": "#/definitions/account-feature/definitions/enabled"
+        },
+        "id": {
+          "$ref": "#/definitions/account-feature/definitions/id"
+        },
+        "name": {
+          "$ref": "#/definitions/account-feature/definitions/name"
+        },
+        "state": {
+          "$ref": "#/definitions/account-feature/definitions/state"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/account-feature/definitions/updated_at"
+        }
+      }
+    },
+    "organization-invitation": {
+      "description": "An organization invitation represents an invite to an organization.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "prototype",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Organization Invitation",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when invitation was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/organization-invitation/definitions/id"
+            }
+          ]
+        },
+        "id": {
+          "description": "Unique identifier of an invitation",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "token": {
+          "description": "Special token for invitation",
+          "example": "614ae25aa2d4802096cd7c18625b526c",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when invitation was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Get a list of an organization's Identity Providers",
+          "title": "List",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fname)}/invitations",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/organization-invitation"
+            },
+            "type": [
+              "array"
+            ]
+          }
+        },
+        {
+          "description": "Create Organization Invitation",
+          "title": "Create",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/invitations",
+          "method": "PUT",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "email": {
+                "$ref": "#/definitions/account/definitions/email"
+              },
+              "role": {
+                "$ref": "#/definitions/organization/definitions/role"
+              }
+            },
+            "required": [
+              "email",
+              "role"
+            ],
+            "type": [
+              "object"
+            ]
+          }
+        },
+        {
+          "description": "Revoke an organization invitation.",
+          "title": "Revoke",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/invitations/{(%23%2Fdefinitions%2Forganization-invitation%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "self"
+        },
+        {
+          "description": "Get an invitation by its token",
+          "title": "Get",
+          "href": "/organizations/invitations/{(%23%2Fdefinitions%2Forganization-invitation%2Fdefinitions%2Ftoken)}",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "$ref": "#/definitions/organization-invitation"
+          }
+        },
+        {
+          "description": "Accept Organization Invitation",
+          "title": "Accept",
+          "href": "/organizations/invitations/{(%23%2Fdefinitions%2Forganization-invitation%2Fdefinitions%2Ftoken)}/accept",
+          "method": "POST",
+          "rel": "create",
+          "targetSchema": {
+            "$ref": "#/definitions/organization-member"
+          }
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/organization-invitation/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/organization-invitation/definitions/id"
+        },
+        "invited_by": {
+          "properties": {
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            },
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/account/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "organization": {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/organization/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/organization/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "role": {
+          "$ref": "#/definitions/organization/definitions/role"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/organization-invitation/definitions/updated_at"
+        },
+        "user": {
+          "properties": {
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            },
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/account/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        }
+      }
+    },
     "organization-invoice": {
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "description": "An organization invoice is an itemized bill of goods for an organization which includes pricing and charges.",
@@ -7028,7 +7872,7 @@
       ],
       "definitions": {
         "addons_total": {
-          "description": "total addons charges in on this invoice",
+          "description": "total add-ons charges in on this invoice",
           "example": 25000,
           "readOnly": true,
           "type": [
@@ -7304,6 +8148,15 @@
             }
           ]
         },
+        "name": {
+          "description": "full name of the organization member",
+          "example": "Tina Edmonds",
+          "readOnly": true,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "two_factor_authentication": {
           "description": "whether the Enterprise organization member has two factor authentication enabled",
           "example": true,
@@ -7354,6 +8207,66 @@
           "title": "Create or Update"
         },
         {
+          "description": "Create a new organization member.",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/members",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "email": {
+                "$ref": "#/definitions/organization-member/definitions/email"
+              },
+              "federated": {
+                "$ref": "#/definitions/organization-member/definitions/federated"
+              },
+              "role": {
+                "$ref": "#/definitions/organization/definitions/role"
+              }
+            },
+            "required": [
+              "email",
+              "role"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/organization-member"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Update an organization member.",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/members",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "email": {
+                "$ref": "#/definitions/organization-member/definitions/email"
+              },
+              "federated": {
+                "$ref": "#/definitions/organization-member/definitions/federated"
+              },
+              "role": {
+                "$ref": "#/definitions/organization/definitions/role"
+              }
+            },
+            "required": [
+              "email",
+              "role"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/organization-member"
+          },
+          "title": "update"
+        },
+        {
           "description": "Remove a member from the organization.",
           "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/members/{(%23%2Fdefinitions%2Forganization-member%2Fdefinitions%2Fidentity)}",
           "method": "DELETE",
@@ -7374,6 +8287,21 @@
           "targetSchema": {
             "items": {
               "$ref": "#/definitions/organization-member"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "List the apps of a member.",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/members/{(%23%2Fdefinitions%2Forganization-member%2Fdefinitions%2Fidentity)}/apps",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/organization-app"
             },
             "type": [
               "array"
@@ -7412,6 +8340,9 @@
             },
             "id": {
               "$ref": "#/definitions/account/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/account/definitions/name"
             }
           },
           "strictProperties": true,
@@ -7421,15 +8352,136 @@
         }
       }
     },
-    "organization-payment-method": {
+    "organization-preferences": {
+      "description": "Tracks an organization's preferences",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
-      "description": "The on file payment method for an organization account.",
       "stability": "prototype",
-      "title": "Heroku Vault API - Organization Payment Method",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Organization Preferences",
       "type": [
         "object"
       ],
       "definitions": {
+        "default-permission": {
+          "description": "The default permission used when adding new members to the organization",
+          "example": "member",
+          "readOnly": false,
+          "enum": [
+            "admin",
+            "member",
+            "viewer",
+            null
+          ],
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "identity": {
+          "$ref": "#/definitions/organization/definitions/identity"
+        },
+        "whitelisting-enabled": {
+          "description": "Whether whitelisting rules should be applied to add-on installations",
+          "example": true,
+          "readOnly": false,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Retrieve Organization Preferences",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization-preferences%2Fdefinitions%2Fidentity)}/preferences",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/organization-preferences"
+          },
+          "title": "List"
+        },
+        {
+          "description": "Update Organization Preferences",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization-preferences%2Fdefinitions%2Fidentity)}/preferences",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "whitelisting-enabled": {
+                "$ref": "#/definitions/organization-preferences/definitions/whitelisting-enabled"
+              }
+            }
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/organization-preferences"
+          },
+          "title": "Update"
+        }
+      ],
+      "properties": {
+        "default-permission": {
+          "$ref": "#/definitions/organization-preferences/definitions/default-permission"
+        },
+        "whitelisting-enabled": {
+          "$ref": "#/definitions/organization-preferences/definitions/whitelisting-enabled"
+        }
+      }
+    },
+    "organization": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "description": "Organizations allow you to manage access to a shared group of applications across your development team.",
+      "stability": "prototype",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Organization",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when the organization was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "credit_card_collections": {
+          "description": "whether charges incurred by the org are paid by credit card.",
+          "example": true,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "default": {
+          "description": "whether to use this organization when none is specified",
+          "example": true,
+          "readOnly": false,
+          "type": [
+            "boolean"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of organization",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/organization/definitions/name"
+            },
+            {
+              "$ref": "#/definitions/organization/definitions/id"
+            }
+          ]
+        },
         "address_1": {
           "type": [
             "string"
@@ -7521,271 +8573,6 @@
           "description": "state",
           "example": "CA"
         },
-        "card_last4": {
-          "type": [
-            "string"
-          ],
-          "description": "last 4 digits of credit card number",
-          "example": "1234",
-          "readOnly": true
-        },
-        "card_type": {
-          "type": [
-            "string"
-          ],
-          "description": "name of credit card issuer",
-          "example": "VISA",
-          "readOnly": true
-        },
-        "heroku_id": {
-          "type": [
-            "string"
-          ],
-          "description": "heroku_id identifier reference",
-          "example": "user930223902@heroku.com",
-          "readOnly": true
-        },
-        "identity": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/invoice-address/definitions/heroku_id"
-            }
-          ]
-        }
-      },
-      "links": [
-        {
-          "description": "Update an existing payment method for an organization account.",
-          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/payment-method",
-          "method": "PATCH",
-          "rel": "update",
-          "schema": {
-            "properties": {
-              "address_1": {
-                "$ref": "#/definitions/organization-payment-method/definitions/address_1"
-              },
-              "address_2": {
-                "$ref": "#/definitions/organization-payment-method/definitions/address_2"
-              },
-              "card_number": {
-                "$ref": "#/definitions/organization-payment-method/definitions/card_number"
-              },
-              "city": {
-                "$ref": "#/definitions/organization-payment-method/definitions/city"
-              },
-              "country": {
-                "$ref": "#/definitions/organization-payment-method/definitions/country"
-              },
-              "cvv": {
-                "$ref": "#/definitions/organization-payment-method/definitions/cvv"
-              },
-              "expiration_month": {
-                "$ref": "#/definitions/organization-payment-method/definitions/expiration_month"
-              },
-              "expiration_year": {
-                "$ref": "#/definitions/organization-payment-method/definitions/expiration_year"
-              },
-              "first_name": {
-                "$ref": "#/definitions/organization-payment-method/definitions/first_name"
-              },
-              "last_name": {
-                "$ref": "#/definitions/organization-payment-method/definitions/last_name"
-              },
-              "other": {
-                "$ref": "#/definitions/organization-payment-method/definitions/other"
-              },
-              "postal_code": {
-                "$ref": "#/definitions/organization-payment-method/definitions/postal_code"
-              },
-              "state": {
-                "$ref": "#/definitions/organization-payment-method/definitions/state"
-              }
-            },
-            "required": [
-              "address_1",
-              "address_2",
-              "card_number",
-              "city",
-              "country",
-              "cvv",
-              "expiration_month",
-              "expiration_year",
-              "first_name",
-              "last_name",
-              "postal_code",
-              "state"
-            ],
-            "type": [
-              "object"
-            ]
-          },
-          "title": "update"
-        },
-        {
-          "description": "Get the current payment method for an organization account.",
-          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/payment-method",
-          "method": "GET",
-          "rel": "self",
-          "targetSchema": {
-            "$ref": "#/definitions/organization-payment-method"
-          },
-          "title": "get"
-        }
-      ],
-      "properties": {
-        "address_1": {
-          "$ref": "#/definitions/organization-payment-method/definitions/address_1"
-        },
-        "address_2": {
-          "$ref": "#/definitions/organization-payment-method/definitions/address_2"
-        },
-        "card_last4": {
-          "$ref": "#/definitions/organization-payment-method/definitions/card_last4"
-        },
-        "card_type": {
-          "$ref": "#/definitions/organization-payment-method/definitions/card_type"
-        },
-        "city": {
-          "$ref": "#/definitions/organization-payment-method/definitions/city"
-        },
-        "country": {
-          "$ref": "#/definitions/organization-payment-method/definitions/country"
-        },
-        "expiration_month": {
-          "$ref": "#/definitions/organization-payment-method/definitions/expiration_month"
-        },
-        "expiration_year": {
-          "$ref": "#/definitions/organization-payment-method/definitions/expiration_year"
-        },
-        "first_name": {
-          "$ref": "#/definitions/organization-payment-method/definitions/first_name"
-        },
-        "last_name": {
-          "$ref": "#/definitions/organization-payment-method/definitions/last_name"
-        },
-        "other": {
-          "$ref": "#/definitions/organization-payment-method/definitions/other"
-        },
-        "postal_code": {
-          "$ref": "#/definitions/organization-payment-method/definitions/postal_code"
-        },
-        "state": {
-          "$ref": "#/definitions/organization-payment-method/definitions/state"
-        }
-      }
-    },
-    "organization-preferences": {
-      "description": "Tracks an organization's preferences",
-      "$schema": "http://json-schema.org/draft-04/hyper-schema",
-      "stability": "prototype",
-      "strictProperties": true,
-      "title": "Heroku Platform API - Organization Preferences",
-      "type": [
-        "object"
-      ],
-      "definitions": {
-        "identity": {
-          "$ref": "#/definitions/organization/definitions/identity"
-        },
-        "whitelisting-enabled": {
-          "description": "Whether whitelisting rules should be applied to add-on installations",
-          "example": true,
-          "readOnly": false,
-          "type": [
-            "boolean",
-            "null"
-          ]
-        }
-      },
-      "links": [
-        {
-          "description": "Retrieve Organization Preferences",
-          "href": "/organizations/{(%23%2Fdefinitions%2Forganization-preferences%2Fdefinitions%2Fidentity)}/preferences",
-          "method": "GET",
-          "rel": "self",
-          "targetSchema": {
-            "$ref": "#/definitions/organization-preferences"
-          },
-          "title": "List"
-        },
-        {
-          "description": "Update Organization Preferences",
-          "href": "/organizations/{(%23%2Fdefinitions%2Forganization-preferences%2Fdefinitions%2Fidentity)}/preferences",
-          "method": "PATCH",
-          "rel": "update",
-          "schema": {
-            "properties": {
-              "whitelisting-enabled": {
-                "$ref": "#/definitions/organization-preferences/definitions/whitelisting-enabled"
-              }
-            }
-          },
-          "targetSchema": {
-            "$ref": "#/definitions/organization-preferences"
-          },
-          "title": "Update"
-        }
-      ],
-      "properties": {
-        "whitelisting-enabled": {
-          "$ref": "#/definitions/organization-preferences/definitions/whitelisting-enabled"
-        }
-      }
-    },
-    "organization": {
-      "$schema": "http://json-schema.org/draft-04/hyper-schema",
-      "description": "Organizations allow you to manage access to a shared group of applications across your development team.",
-      "stability": "prototype",
-      "strictProperties": true,
-      "title": "Heroku Platform API - Organization",
-      "type": [
-        "object"
-      ],
-      "definitions": {
-        "created_at": {
-          "description": "when the organization was created",
-          "example": "2012-01-01T12:00:00Z",
-          "format": "date-time",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "credit_card_collections": {
-          "description": "whether charges incurred by the org are paid by credit card.",
-          "example": true,
-          "readOnly": true,
-          "type": [
-            "boolean"
-          ]
-        },
-        "default": {
-          "description": "whether to use this organization when none is specified",
-          "example": true,
-          "readOnly": false,
-          "type": [
-            "boolean"
-          ]
-        },
-        "id": {
-          "description": "unique identifier of organization",
-          "example": "01234567-89ab-cdef-0123-456789abcdef",
-          "format": "uuid",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "identity": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/organization/definitions/name"
-            },
-            {
-              "$ref": "#/definitions/organization/definitions/id"
-            }
-          ]
-        },
         "membership_limit": {
           "description": "upper limit of members allowed in an organization.",
           "example": 25,
@@ -7873,7 +8660,7 @@
           "title": "Info"
         },
         {
-          "description": "Set or unset the organization as your default organization.",
+          "description": "Update organization properties.",
           "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}",
           "method": "PATCH",
           "rel": "update",
@@ -7881,6 +8668,9 @@
             "properties": {
               "default": {
                 "$ref": "#/definitions/organization/definitions/default"
+              },
+              "name": {
+                "$ref": "#/definitions/organization/definitions/name"
               }
             },
             "type": [
@@ -7903,43 +8693,43 @@
                 "$ref": "#/definitions/organization/definitions/name"
               },
               "address_1": {
-                "$ref": "#/definitions/payment-method/definitions/address_1"
+                "$ref": "#/definitions/organization/definitions/address_1"
               },
               "address_2": {
-                "$ref": "#/definitions/payment-method/definitions/address_2"
+                "$ref": "#/definitions/organization/definitions/address_2"
               },
               "card_number": {
-                "$ref": "#/definitions/payment-method/definitions/card_number"
+                "$ref": "#/definitions/organization/definitions/card_number"
               },
               "city": {
-                "$ref": "#/definitions/payment-method/definitions/city"
+                "$ref": "#/definitions/organization/definitions/city"
               },
               "country": {
-                "$ref": "#/definitions/payment-method/definitions/country"
+                "$ref": "#/definitions/organization/definitions/country"
               },
               "cvv": {
-                "$ref": "#/definitions/payment-method/definitions/cvv"
+                "$ref": "#/definitions/organization/definitions/cvv"
               },
               "expiration_month": {
-                "$ref": "#/definitions/payment-method/definitions/expiration_month"
+                "$ref": "#/definitions/organization/definitions/expiration_month"
               },
               "expiration_year": {
-                "$ref": "#/definitions/payment-method/definitions/expiration_year"
+                "$ref": "#/definitions/organization/definitions/expiration_year"
               },
               "first_name": {
-                "$ref": "#/definitions/payment-method/definitions/first_name"
+                "$ref": "#/definitions/organization/definitions/first_name"
               },
               "last_name": {
-                "$ref": "#/definitions/payment-method/definitions/last_name"
+                "$ref": "#/definitions/organization/definitions/last_name"
               },
               "other": {
-                "$ref": "#/definitions/payment-method/definitions/other"
+                "$ref": "#/definitions/organization/definitions/other"
               },
               "postal_code": {
-                "$ref": "#/definitions/payment-method/definitions/postal_code"
+                "$ref": "#/definitions/organization/definitions/postal_code"
               },
               "state": {
-                "$ref": "#/definitions/payment-method/definitions/state"
+                "$ref": "#/definitions/organization/definitions/state"
               }
             },
             "required": [
@@ -7995,86 +8785,6 @@
         },
         "updated_at": {
           "$ref": "#/definitions/organization/definitions/updated_at"
-        }
-      }
-    },
-    "otp-secret": {
-      "description": "This renders a secret that clients can use to build a one-time password to be supplied as a 2nd factor of authentication.",
-      "$schema": "http://json-schema.org/draft-04/hyper-schema",
-      "stability": "development",
-      "strictProperties": true,
-      "title": "Heroku Platform API - OTP Secret",
-      "type": [
-        "object"
-      ],
-      "definitions": {
-        "created_at": {
-          "description": "when OTP secret was created",
-          "example": "2012-01-01T12:00:00Z",
-          "format": "date-time",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "id": {
-          "description": "unique identifier of OTP secret",
-          "example": "01234567-89ab-cdef-0123-456789abcdef",
-          "format": "uuid",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "identity": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/otp-secret/definitions/id"
-            }
-          ]
-        },
-        "updated_at": {
-          "description": "when OTP secret was updated",
-          "example": "2012-01-01T12:00:00Z",
-          "format": "date-time",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "url": {
-          "description": "OTP secret rendered in URL format",
-          "example": "otpauth://totp/username@example.com?issuer=Heroku&secret=abcd1234",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        }
-      },
-      "links": [
-        {
-          "description": "Create new OTP secret. This invalidates any existing OTP secrets on the account.",
-          "href": "/account/otp-secret",
-          "method": "POST",
-          "rel": "create",
-          "targetSchema": {
-            "$ref": "#/definitions/otp-secret"
-          },
-          "title": "Create"
-        }
-      ],
-      "properties": {
-        "created_at": {
-          "$ref": "#/definitions/otp-secret/definitions/created_at"
-        },
-        "id": {
-          "$ref": "#/definitions/otp-secret/definitions/id"
-        },
-        "updated_at": {
-          "$ref": "#/definitions/otp-secret/definitions/updated_at"
-        },
-        "url": {
-          "$ref": "#/definitions/otp-secret/definitions/url"
         }
       }
     },
@@ -8344,421 +9054,6 @@
           "type": [
             "object"
           ]
-        }
-      }
-    },
-    "payment-method": {
-      "$schema": "http://json-schema.org/draft-04/hyper-schema",
-      "description": "The on file payment method for an account",
-      "stability": "prototype",
-      "title": "Heroku Vault API - Payment Method",
-      "type": [
-        "object"
-      ],
-      "definitions": {
-        "address_1": {
-          "type": [
-            "string"
-          ],
-          "description": "street address line 1",
-          "example": "40 Hickory Lane"
-        },
-        "address_2": {
-          "type": [
-            "string"
-          ],
-          "description": "street address line 2",
-          "example": "Suite 103"
-        },
-        "card_number": {
-          "type": [
-            "string"
-          ],
-          "description": "encrypted card number of payment method",
-          "example": "encrypted-card-number"
-        },
-        "city": {
-          "type": [
-            "string"
-          ],
-          "description": "city",
-          "example": "San Francisco"
-        },
-        "country": {
-          "type": [
-            "string"
-          ],
-          "description": "country",
-          "example": "US"
-        },
-        "cvv": {
-          "type": [
-            "string"
-          ],
-          "description": "card verification value",
-          "example": "123"
-        },
-        "expiration_month": {
-          "type": [
-            "string"
-          ],
-          "description": "expiration month",
-          "example": "11"
-        },
-        "expiration_year": {
-          "type": [
-            "string"
-          ],
-          "description": "expiration year",
-          "example": "2014"
-        },
-        "first_name": {
-          "type": [
-            "string"
-          ],
-          "description": "the first name for payment method",
-          "example": "Jason"
-        },
-        "last_name": {
-          "type": [
-            "string"
-          ],
-          "description": "the last name for payment method",
-          "example": "Walker"
-        },
-        "other": {
-          "type": [
-            "string"
-          ],
-          "description": "metadata",
-          "example": "Additional information for payment method"
-        },
-        "postal_code": {
-          "type": [
-            "string"
-          ],
-          "description": "postal code",
-          "example": "90210"
-        },
-        "state": {
-          "type": [
-            "string"
-          ],
-          "description": "state",
-          "example": "CA"
-        },
-        "card_last4": {
-          "type": [
-            "string"
-          ],
-          "description": "last 4 digits of credit card number",
-          "example": "1234",
-          "readOnly": true
-        },
-        "card_type": {
-          "type": [
-            "string"
-          ],
-          "description": "name of credit card issuer",
-          "example": "VISA",
-          "readOnly": true
-        },
-        "heroku_id": {
-          "type": [
-            "string"
-          ],
-          "description": "heroku_id identifier reference",
-          "example": "user930223902@heroku.com",
-          "readOnly": true
-        },
-        "identity": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/invoice-address/definitions/heroku_id"
-            }
-          ]
-        }
-      },
-      "links": [
-        {
-          "description": "Update an existing payment method for an account.",
-          "href": "/account/payment-method",
-          "method": "PATCH",
-          "rel": "update",
-          "schema": {
-            "properties": {
-              "address_1": {
-                "$ref": "#/definitions/payment-method/definitions/address_1"
-              },
-              "address_2": {
-                "$ref": "#/definitions/payment-method/definitions/address_2"
-              },
-              "card_number": {
-                "$ref": "#/definitions/payment-method/definitions/card_number"
-              },
-              "city": {
-                "$ref": "#/definitions/payment-method/definitions/city"
-              },
-              "country": {
-                "$ref": "#/definitions/payment-method/definitions/country"
-              },
-              "cvv": {
-                "$ref": "#/definitions/payment-method/definitions/cvv"
-              },
-              "expiration_month": {
-                "$ref": "#/definitions/payment-method/definitions/expiration_month"
-              },
-              "expiration_year": {
-                "$ref": "#/definitions/payment-method/definitions/expiration_year"
-              },
-              "first_name": {
-                "$ref": "#/definitions/payment-method/definitions/first_name"
-              },
-              "last_name": {
-                "$ref": "#/definitions/payment-method/definitions/last_name"
-              },
-              "other": {
-                "$ref": "#/definitions/payment-method/definitions/other"
-              },
-              "postal_code": {
-                "$ref": "#/definitions/payment-method/definitions/postal_code"
-              },
-              "state": {
-                "$ref": "#/definitions/payment-method/definitions/state"
-              }
-            },
-            "required": [
-              "address_1",
-              "address_2",
-              "card_number",
-              "city",
-              "country",
-              "cvv",
-              "expiration_month",
-              "expiration_year",
-              "first_name",
-              "last_name",
-              "postal_code",
-              "state"
-            ],
-            "type": [
-              "object"
-            ]
-          },
-          "title": "update"
-        },
-        {
-          "description": "Get the current payment method for an account.",
-          "href": "/account/payment-method",
-          "method": "GET",
-          "rel": "self",
-          "targetSchema": {
-            "$ref": "#/definitions/payment-method"
-          },
-          "title": "get"
-        }
-      ],
-      "properties": {
-        "address_1": {
-          "$ref": "#/definitions/payment-method/definitions/address_1"
-        },
-        "address_2": {
-          "$ref": "#/definitions/payment-method/definitions/address_2"
-        },
-        "card_last4": {
-          "$ref": "#/definitions/payment-method/definitions/card_last4"
-        },
-        "card_type": {
-          "$ref": "#/definitions/payment-method/definitions/card_type"
-        },
-        "city": {
-          "$ref": "#/definitions/payment-method/definitions/city"
-        },
-        "country": {
-          "$ref": "#/definitions/payment-method/definitions/country"
-        },
-        "expiration_month": {
-          "$ref": "#/definitions/payment-method/definitions/expiration_month"
-        },
-        "expiration_year": {
-          "$ref": "#/definitions/payment-method/definitions/expiration_year"
-        },
-        "first_name": {
-          "$ref": "#/definitions/payment-method/definitions/first_name"
-        },
-        "last_name": {
-          "$ref": "#/definitions/payment-method/definitions/last_name"
-        },
-        "other": {
-          "$ref": "#/definitions/payment-method/definitions/other"
-        },
-        "postal_code": {
-          "$ref": "#/definitions/payment-method/definitions/postal_code"
-        },
-        "state": {
-          "$ref": "#/definitions/payment-method/definitions/state"
-        }
-      }
-    },
-    "payment": {
-      "$schema": "http://json-schema.org/draft-04/hyper-schema",
-      "description": "A payment represents money collected for an account",
-      "title": "Heroku Vault API - Payments",
-      "stability": "prototype",
-      "type": [
-        "object"
-      ],
-      "definitions": {
-        "account_id": {
-          "type": [
-            "integer"
-          ],
-          "description": "account that payment belongs to",
-          "example": 8403923,
-          "readOnly": true
-        },
-        "amount": {
-          "type": [
-            "number"
-          ],
-          "description": "amount of payment in cents",
-          "example": 50000,
-          "readOnly": false
-        },
-        "created_at": {
-          "description": "when payment was created",
-          "example": "2012-01-01T12:00:00Z",
-          "format": "date-time",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "id": {
-          "type": [
-            "integer"
-          ],
-          "description": "legacy unique identifier of payment",
-          "example": 9403943,
-          "readOnly": true
-        },
-        "identity": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/payment/definitions/id"
-            }
-          ]
-        },
-        "state": {
-          "enum": [
-            "failure",
-            "pending",
-            "success"
-          ],
-          "type": [
-            "string"
-          ],
-          "description": "state of the payment",
-          "example": "pending",
-          "readOnly": true
-        },
-        "updated_at": {
-          "description": "when credit was updated",
-          "example": "2012-01-01T12:00:00Z",
-          "format": "date-time",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "uuid": {
-          "description": "unique identifier for a payment transaction",
-          "example": "01234567-89ab-cdef-0123-456789abcdef",
-          "format": "uuid",
-          "readOnly": false,
-          "type": [
-            "string"
-          ]
-        }
-      },
-      "links": [
-        {
-          "description": "Create a payment on an existing account",
-          "href": "/account/payments",
-          "method": "POST",
-          "rel": "self",
-          "schema": {
-            "properties": {
-              "amount": {
-                "$ref": "#/definitions/payment/definitions/amount"
-              },
-              "invoice": {
-                "$ref": "#/definitions/invoice/definitions/identity"
-              },
-              "uuid": {
-                "$ref": "#/definitions/payment/definitions/uuid"
-              }
-            },
-            "required": [
-              "amount",
-              "invoice",
-              "uuid"
-            ],
-            "type": [
-              "object"
-            ]
-          },
-          "targetSchema": {
-            "$ref": "#/definitions/payment"
-          },
-          "title": "create"
-        }
-      ],
-      "properties": {
-        "amount": {
-          "$ref": "#/definitions/payment/definitions/amount"
-        },
-        "created_at": {
-          "$ref": "#/definitions/payment/definitions/created_at"
-        },
-        "id": {
-          "$ref": "#/definitions/payment/definitions/id"
-        },
-        "invoice": {
-          "description": "identity of invoice",
-          "properties": {
-            "id": {
-              "$ref": "#/definitions/invoice/definitions/id"
-            },
-            "number": {
-              "$ref": "#/definitions/invoice/definitions/number"
-            }
-          },
-          "type": [
-            "null",
-            "object"
-          ]
-        },
-        "updated_at": {
-          "$ref": "#/definitions/payment/definitions/updated_at"
-        },
-        "user": {
-          "description": "identity of user issuing payment",
-          "properties": {
-            "email": {
-              "$ref": "#/definitions/account/definitions/email"
-            },
-            "id": {
-              "$ref": "#/definitions/account/definitions/id"
-            }
-          },
-          "strictProperties": true,
-          "type": [
-            "object"
-          ]
-        },
-        "state": {
-          "$ref": "#/definitions/payment/definitions/state"
         }
       }
     },
@@ -9507,8 +9802,22 @@
             "string"
           ]
         },
+        "compliance": {
+          "description": "the compliance regimes applied to an add-on plan",
+          "example": [
+            "HIPAA"
+          ],
+          "readOnly": false,
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "$ref": "#/definitions/plan/definitions/regime"
+          }
+        },
         "default": {
-          "description": "whether this plan is the default for its addon service",
+          "description": "whether this plan is the default for its add-on service",
           "example": false,
           "readOnly": true,
           "type": [
@@ -9524,7 +9833,7 @@
           ]
         },
         "human_name": {
-          "description": "human readable name of the addon plan",
+          "description": "human readable name of the add-on plan",
           "example": "Dev",
           "readOnly": true,
           "type": [
@@ -9574,6 +9883,18 @@
             "string"
           ]
         },
+        "regime": {
+          "description": "compliance requirements an add-on plan must adhere to",
+          "readOnly": true,
+          "example": "HIPAA",
+          "type": [
+            "string"
+          ],
+          "enum": [
+            "HIPAA",
+            "PCI"
+          ]
+        },
         "cents": {
           "description": "price in cents per unit of plan",
           "example": 0,
@@ -9614,12 +9935,20 @@
           "type": [
             "string"
           ]
+        },
+        "visible": {
+          "description": "whether this plan is publicly visible",
+          "example": true,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
         }
       },
       "links": [
         {
           "description": "Info for existing plan.",
-          "href": "/addon-services/{(%23%2Fdefinitions%2Faddon-service%2Fdefinitions%2Fidentity)}/plans/{(%23%2Fdefinitions%2Fplan%2Fdefinitions%2Fidentity)}",
+          "href": "/addon-services/{(%23%2Fdefinitions%2Fadd-on-service%2Fdefinitions%2Fidentity)}/plans/{(%23%2Fdefinitions%2Fplan%2Fdefinitions%2Fidentity)}",
           "method": "GET",
           "rel": "self",
           "targetSchema": {
@@ -9629,7 +9958,7 @@
         },
         {
           "description": "List existing plans.",
-          "href": "/addon-services/{(%23%2Fdefinitions%2Faddon-service%2Fdefinitions%2Fidentity)}/plans",
+          "href": "/addon-services/{(%23%2Fdefinitions%2Fadd-on-service%2Fdefinitions%2Fidentity)}/plans",
           "method": "GET",
           "rel": "instances",
           "targetSchema": {
@@ -9648,10 +9977,10 @@
           "description": "identity of add-on service",
           "properties": {
             "id": {
-              "$ref": "#/definitions/addon-service/definitions/id"
+              "$ref": "#/definitions/add-on-service/definitions/id"
             },
             "name": {
-              "$ref": "#/definitions/addon-service/definitions/name"
+              "$ref": "#/definitions/add-on-service/definitions/name"
             }
           },
           "strictProperties": true,
@@ -9661,6 +9990,9 @@
         },
         "created_at": {
           "$ref": "#/definitions/plan/definitions/created_at"
+        },
+        "compliance": {
+          "$ref": "#/definitions/plan/definitions/compliance"
         },
         "default": {
           "$ref": "#/definitions/plan/definitions/default"
@@ -9706,6 +10038,9 @@
         },
         "updated_at": {
           "$ref": "#/definitions/plan/definitions/updated_at"
+        },
+        "visible": {
+          "$ref": "#/definitions/plan/definitions/visible"
         }
       }
     },
@@ -9747,34 +10082,6 @@
           "$ref": "#/definitions/rate-limit/definitions/remaining"
         }
       }
-    },
-    "recovery-code": {
-      "description": "Recovery codes grant access to accounts with two-factor authentication enabled.",
-      "$schema": "http://json-schema.org/draft-04/hyper-schema",
-      "stability": "development",
-      "strictProperties": true,
-      "title": "Heroku Platform API - Recovery Code",
-      "type": [
-        "array"
-      ],
-      "items": {
-        "example": "0123456789abcdef",
-        "type": [
-          "string"
-        ]
-      },
-      "links": [
-        {
-          "description": "Generate new recovery codes. This invalidates any existing codes on the account.",
-          "href": "/account/recovery-codes",
-          "method": "POST",
-          "rel": "create",
-          "targetSchema": {
-            "$ref": "#/definitions/recovery-code"
-          },
-          "title": "Create"
-        }
-      ]
     },
     "region": {
       "description": "A region represents a geographic location in which your application may run.",
@@ -10108,6 +10415,15 @@
         }
       ],
       "properties": {
+        "addon_plan_names": {
+          "description": "add-on plans installed on the app for this release",
+          "type": [
+            "array"
+          ],
+          "items": {
+            "$ref": "#/definitions/plan/definitions/name"
+          }
+        },
         "app": {
           "description": "app involved in the release",
           "properties": {
@@ -10259,7 +10575,7 @@
             "web": "./bin/web -p $PORT"
           },
           "patternProperties": {
-            "^\\w+$": {
+            "^[-\\w]{1,128}$": {
               "type": [
                 "string"
               ]
@@ -10481,6 +10797,305 @@
         }
       }
     },
+    "sni-endpoint": {
+      "description": "SNI Endpoint is a public address serving a custom SSL cert for HTTPS traffic, using the SNI TLS extension, to a Heroku app. Note: only apps with the `http-sni` and `stable-cname` feature flags or those owned by a user with the `user-http-sni` and `user-stable-cname` feature flags are authorized to use this endpoint.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "title": "Heroku Platform API - SNI Endpoint",
+      "stability": "prototype",
+      "strictProperties": true,
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "app": {
+          "description": "app receiving the new endpoint",
+          "example": "253c2ffd-192d-4a6f-913e-2f7af25a87ef",
+          "format": "uuid",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "ca_signed?": {
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "cert_domains": {
+          "readOnly": true,
+          "type": [
+            "array"
+          ]
+        },
+        "certificate_chain": {
+          "description": "raw contents of the public certificate chain (eg: .crt or .pem file)",
+          "example": "-----BEGIN CERTIFICATE----- ...",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "cname": {
+          "description": "canonical name record, the address to point a domain at",
+          "example": "example.herokussl.com",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "created_at": {
+          "description": "when endpoint was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "expires_at": {
+          "readOnly": true,
+          "format": "date-time",
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of this SNI endpoint",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/sni-endpoint/definitions/id"
+            },
+            {
+              "$ref": "#/definitions/sni-endpoint/definitions/name"
+            }
+          ]
+        },
+        "issuer": {
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "name": {
+          "description": "unique name for SNI endpoint",
+          "example": "example",
+          "pattern": "^[a-z][a-z0-9-]{2,29}$",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "private_key": {
+          "description": "contents of the private key (eg .key file)",
+          "example": "-----BEGIN RSA PRIVATE KEY----- ...",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "self_signed?": {
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "starts_at": {
+          "readOnly": true,
+          "format": "date-time",
+          "type": [
+            "string"
+          ]
+        },
+        "subject": {
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when SNI endpoint was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Create a new SNI endpoint.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/sni-endpoints",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "app": {
+                "$ref": "#/definitions/sni-endpoint/definitions/app"
+              },
+              "certificate_chain": {
+                "$ref": "#/definitions/sni-endpoint/definitions/certificate_chain"
+              },
+              "private_key": {
+                "$ref": "#/definitions/sni-endpoint/definitions/private_key"
+              }
+            },
+            "required": [
+              "certificate_chain",
+              "private_key"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/sni-endpoint"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Delete existing SNI endpoint.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/sni-endpoints/{(%23%2Fdefinitions%2Fsni-endpoint%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/sni-endpoint"
+          },
+          "title": "Delete"
+        },
+        {
+          "description": "Info for existing SNI endpoint.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/sni-endpoints/{(%23%2Fdefinitions%2Fsni-endpoint%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/sni-endpoint"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List existing SNI endpoints.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/sni-endpoints",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/sni-endpoint"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "Update an existing SNI endpoint.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/sni-endpoints/{(%23%2Fdefinitions%2Fsni-endpoint%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "certificate_chain": {
+                "$ref": "#/definitions/sni-endpoint/definitions/certificate_chain"
+              },
+              "private_key": {
+                "$ref": "#/definitions/sni-endpoint/definitions/private_key"
+              }
+            },
+            "required": [
+              "certificate_chain",
+              "private_key"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/sni-endpoint"
+          },
+          "title": "Update"
+        }
+      ],
+      "properties": {
+        "app": {
+          "description": "application associated with this sni-endpoint",
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/app/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/app/definitions/name"
+            }
+          },
+          "strictProperties": true
+        },
+        "certificate_chain": {
+          "$ref": "#/definitions/sni-endpoint/definitions/certificate_chain"
+        },
+        "cname": {
+          "$ref": "#/definitions/sni-endpoint/definitions/cname"
+        },
+        "created_at": {
+          "$ref": "#/definitions/sni-endpoint/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/sni-endpoint/definitions/id"
+        },
+        "name": {
+          "$ref": "#/definitions/sni-endpoint/definitions/name"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/sni-endpoint/definitions/updated_at"
+        },
+        "ssl_cert": {
+          "description": "certificate provided by this endpoint",
+          "properties": {
+            "ca_signed?": {
+              "$ref": "#/definitions/sni-endpoint/definitions/ca_signed?"
+            },
+            "cert_domains": {
+              "$ref": "#/definitions/sni-endpoint/definitions/cert_domains"
+            },
+            "expires_at": {
+              "$ref": "#/definitions/sni-endpoint/definitions/expires_at"
+            },
+            "issuer": {
+              "$ref": "#/definitions/sni-endpoint/definitions/issuer"
+            },
+            "self_signed?": {
+              "$ref": "#/definitions/sni-endpoint/definitions/self_signed?"
+            },
+            "starts_at": {
+              "$ref": "#/definitions/sni-endpoint/definitions/starts_at"
+            },
+            "subject": {
+              "$ref": "#/definitions/sni-endpoint/definitions/subject"
+            },
+            "id": {
+              "description": "unique identifier of this SSL certificate",
+              "example": "01234567-89ab-cdef-0123-456789abcdef",
+              "format": "uuid",
+              "readOnly": true,
+              "type": [
+                "string"
+              ]
+            }
+          }
+        }
+      }
+    },
     "source": {
       "description": "A source is a location for uploading and downloading an application's source code.",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
@@ -10528,7 +11143,7 @@
           "targetSchema": {
             "$ref": "#/definitions/source"
           },
-          "title": "Create (Deprecated)"
+          "title": "Create - Deprecated"
         }
       ],
       "properties": {
@@ -10795,32 +11410,6 @@
         "object"
       ],
       "definitions": {
-        "regime": {
-          "description": "compliance requirements a space must adhere to",
-          "readOnly": true,
-          "example": "HIPAA",
-          "type": [
-            "string"
-          ],
-          "enum": [
-            "HIPAA",
-            "PCI"
-          ]
-        },
-        "compliance": {
-          "description": "the compliance regimes applied to a space",
-          "example": [
-            "HIPAA"
-          ],
-          "readOnly": false,
-          "type": [
-            "null",
-            "array"
-          ],
-          "items": {
-            "$ref": "#/definitions/space/definitions/regime"
-          }
-        },
         "created_at": {
           "description": "when space was created",
           "example": "2012-01-01T12:00:00Z",
@@ -10856,6 +11445,14 @@
           "pattern": "^[a-z0-9](?:[a-z0-9]|-(?!-))+[a-z0-9]$",
           "type": [
             "string"
+          ]
+        },
+        "shield": {
+          "description": "true if this space has shield enabled",
+          "readOnly": true,
+          "example": true,
+          "type": [
+            "boolean"
           ]
         },
         "state": {
@@ -10947,15 +11544,19 @@
               "name": {
                 "$ref": "#/definitions/space/definitions/name"
               },
+              "organization": {
+                "$ref": "#/definitions/organization/definitions/name"
+              },
               "region": {
                 "$ref": "#/definitions/region/definitions/identity"
               },
-              "compliance": {
-                "$ref": "#/definitions/space/definitions/compliance"
+              "shield": {
+                "$ref": "#/definitions/space/definitions/shield"
               }
             },
             "required": [
-              "name"
+              "name",
+              "organization"
             ],
             "type": [
               "object"
@@ -10968,9 +11569,6 @@
         }
       ],
       "properties": {
-        "compliance": {
-          "$ref": "#/definitions/space/definitions/compliance"
-        },
         "created_at": {
           "$ref": "#/definitions/space/definitions/created_at"
         },
@@ -10988,7 +11586,6 @@
             }
           },
           "type": [
-            "null",
             "object"
           ]
         },
@@ -11007,6 +11604,9 @@
             "object"
           ]
         },
+        "shield": {
+          "$ref": "#/definitions/space/definitions/shield"
+        },
         "state": {
           "$ref": "#/definitions/space/definitions/state"
         },
@@ -11016,7 +11616,7 @@
       }
     },
     "ssl-endpoint": {
-      "description": "[SSL Endpoint](https://devcenter.heroku.com/articles/ssl-endpoint) is a public address serving custom SSL cert for HTTPS traffic to a Heroku app. Note that an app must have the `ssl:endpoint` addon installed before it can provision an SSL Endpoint using these APIs.",
+      "description": "[SSL Endpoint](https://devcenter.heroku.com/articles/ssl-endpoint) is a public address serving custom SSL cert for HTTPS traffic to a Heroku app. Note that an app must have the `ssl:endpoint` add-on installed before it can provision an SSL Endpoint using these APIs.",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "title": "Heroku Platform API - SSL Endpoint",
       "stability": "production",
@@ -11211,6 +11811,21 @@
         }
       ],
       "properties": {
+        "app": {
+          "description": "application associated with this ssl-endpoint",
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/app/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/app/definitions/name"
+            }
+          },
+          "strictProperties": true
+        },
         "certificate_chain": {
           "$ref": "#/definitions/ssl-endpoint/definitions/certificate_chain"
         },
@@ -11553,7 +12168,7 @@
         }
       }
     },
-    "whitelisted-addon-service": {
+    "whitelisted-add-on-service": {
       "description": "Entities that have been whitelisted to be used by an Organization",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "stability": "prototype",
@@ -11576,10 +12191,18 @@
           "description": "the user which whitelisted the Add-on Service",
           "properties": {
             "email": {
-              "$ref": "#/definitions/account/definitions/email"
+              "$ref": "#/definitions/account/definitions/email",
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "id": {
-              "$ref": "#/definitions/account/definitions/id"
+              "$ref": "#/definitions/account/definitions/id",
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "readOnly": true,
@@ -11591,13 +12214,13 @@
           "description": "the Add-on Service whitelisted for use",
           "properties": {
             "id": {
-              "$ref": "#/definitions/addon-service/definitions/id"
+              "$ref": "#/definitions/add-on-service/definitions/id"
             },
             "name": {
-              "$ref": "#/definitions/addon-service/definitions/name"
+              "$ref": "#/definitions/add-on-service/definitions/name"
             },
             "human_name": {
-              "$ref": "#/definitions/addon-service/definitions/human_name"
+              "$ref": "#/definitions/add-on-service/definitions/human_name"
             }
           },
           "readOnly": true,
@@ -11617,10 +12240,10 @@
         "identity": {
           "anyOf": [
             {
-              "$ref": "#/definitions/whitelisted-addon-service/definitions/id"
+              "$ref": "#/definitions/whitelisted-add-on-service/definitions/id"
             },
             {
-              "$ref": "#/definitions/addon-service/definitions/name"
+              "$ref": "#/definitions/add-on-service/definitions/name"
             }
           ]
         }
@@ -11633,7 +12256,7 @@
           "rel": "instances",
           "targetSchema": {
             "items": {
-              "$ref": "#/definitions/whitelisted-addon-service"
+              "$ref": "#/definitions/whitelisted-add-on-service"
             },
             "type": [
               "array"
@@ -11659,7 +12282,7 @@
           },
           "targetSchema": {
             "items": {
-              "$ref": "#/definitions/whitelisted-addon-service"
+              "$ref": "#/definitions/whitelisted-add-on-service"
             },
             "type": [
               "array"
@@ -11669,302 +12292,27 @@
         },
         {
           "description": "Remove a whitelisted entity",
-          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/whitelisted-addon-services/{(%23%2Fdefinitions%2Fwhitelisted-addon-service%2Fdefinitions%2Fidentity)}",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/whitelisted-addon-services/{(%23%2Fdefinitions%2Fwhitelisted-add-on-service%2Fdefinitions%2Fidentity)}",
           "method": "DELETE",
           "rel": "destroy",
           "targetSchema": {
-            "$ref": "#/definitions/whitelisted-addon-service"
+            "$ref": "#/definitions/whitelisted-add-on-service"
           },
           "title": "Delete"
         }
       ],
       "properties": {
         "added_at": {
-          "$ref": "#/definitions/whitelisted-addon-service/definitions/added_at"
+          "$ref": "#/definitions/whitelisted-add-on-service/definitions/added_at"
         },
         "added_by": {
-          "$ref": "#/definitions/whitelisted-addon-service/definitions/added_by"
+          "$ref": "#/definitions/whitelisted-add-on-service/definitions/added_by"
         },
         "addon_service": {
-          "$ref": "#/definitions/whitelisted-addon-service/definitions/addon_service"
+          "$ref": "#/definitions/whitelisted-add-on-service/definitions/addon_service"
         },
         "id": {
-          "$ref": "#/definitions/whitelisted-addon-service/definitions/id"
-        }
-      }
-    },
-    "sni-endpoint": {
-      "description": "SNI Endpoint is a public address serving a custom SSL cert for HTTPS traffic, using the SNI TLS extension, to a Heroku app. Note: only apps with the `http-sni` and `stable-cname` feature flags or those owned by a user with the `user-http-sni` and `user-stable-cname` feature flags are authorized to use this endpoint.",
-      "$schema": "http://json-schema.org/draft-04/hyper-schema",
-      "title": "Heroku Platform API - SNI Endpoint",
-      "stability": "prototype",
-      "strictProperties": true,
-      "type": [
-        "object"
-      ],
-      "definitions": {
-        "app": {
-          "description": "app receiving the new endpoint",
-          "example": "253c2ffd-192d-4a6f-913e-2f7af25a87ef",
-          "format": "uuid",
-          "readOnly": false,
-          "type": [
-            "string"
-          ]
-        },
-        "ca_signed?": {
-          "readOnly": true,
-          "type": [
-            "boolean"
-          ]
-        },
-        "cert_domains": {
-          "readOnly": true,
-          "type": [
-            "array"
-          ]
-        },
-        "certificate_chain": {
-          "description": "raw contents of the public certificate chain (eg: .crt or .pem file)",
-          "example": "-----BEGIN CERTIFICATE----- ...",
-          "readOnly": false,
-          "type": [
-            "string"
-          ]
-        },
-        "cname": {
-          "description": "canonical name record, the address to point a domain at",
-          "example": "example.herokussl.com",
-          "readOnly": false,
-          "type": [
-            "string"
-          ]
-        },
-        "created_at": {
-          "description": "when endpoint was created",
-          "example": "2012-01-01T12:00:00Z",
-          "format": "date-time",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "expires_at": {
-          "readOnly": true,
-          "format": "date-time",
-          "type": [
-            "string"
-          ]
-        },
-        "id": {
-          "description": "unique identifier of this SNI endpoint",
-          "example": "01234567-89ab-cdef-0123-456789abcdef",
-          "format": "uuid",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "identity": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/sni-endpoint/definitions/id"
-            },
-            {
-              "$ref": "#/definitions/sni-endpoint/definitions/name"
-            }
-          ]
-        },
-        "issuer": {
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "name": {
-          "description": "unique name for SNI endpoint",
-          "example": "example",
-          "pattern": "^[a-z][a-z0-9-]{2,29}$",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "private_key": {
-          "description": "contents of the private key (eg .key file)",
-          "example": "-----BEGIN RSA PRIVATE KEY----- ...",
-          "readOnly": false,
-          "type": [
-            "string"
-          ]
-        },
-        "self_signed?": {
-          "readOnly": true,
-          "type": [
-            "boolean"
-          ]
-        },
-        "starts_at": {
-          "readOnly": true,
-          "format": "date-time",
-          "type": [
-            "string"
-          ]
-        },
-        "subject": {
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
-        "updated_at": {
-          "description": "when SNI endpoint was updated",
-          "example": "2012-01-01T12:00:00Z",
-          "format": "date-time",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        }
-      },
-      "links": [
-        {
-          "description": "Create a new SNI endpoint.",
-          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/sni-endpoints",
-          "method": "POST",
-          "rel": "create",
-          "schema": {
-            "properties": {
-              "app": {
-                "$ref": "#/definitions/sni-endpoint/definitions/app"
-              },
-              "certificate_chain": {
-                "$ref": "#/definitions/sni-endpoint/definitions/certificate_chain"
-              },
-              "private_key": {
-                "$ref": "#/definitions/sni-endpoint/definitions/private_key"
-              }
-            },
-            "required": [
-              "certificate_chain",
-              "private_key"
-            ],
-            "type": [
-              "object"
-            ]
-          },
-          "targetSchema": {
-            "$ref": "#/definitions/sni-endpoint"
-          },
-          "title": "Create"
-        },
-        {
-          "description": "Delete existing SNI endpoint.",
-          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/sni-endpoints/{(%23%2Fdefinitions%2Fsni-endpoint%2Fdefinitions%2Fidentity)}",
-          "method": "DELETE",
-          "rel": "destroy",
-          "targetSchema": {
-            "$ref": "#/definitions/sni-endpoint"
-          },
-          "title": "Delete"
-        },
-        {
-          "description": "Info for existing SNI endpoint.",
-          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/sni-endpoints/{(%23%2Fdefinitions%2Fsni-endpoint%2Fdefinitions%2Fidentity)}",
-          "method": "GET",
-          "rel": "self",
-          "targetSchema": {
-            "$ref": "#/definitions/sni-endpoint"
-          },
-          "title": "Info"
-        },
-        {
-          "description": "List existing SNI endpoints.",
-          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/sni-endpoints",
-          "method": "GET",
-          "rel": "instances",
-          "targetSchema": {
-            "items": {
-              "$ref": "#/definitions/sni-endpoint"
-            },
-            "type": [
-              "array"
-            ]
-          },
-          "title": "List"
-        },
-        {
-          "description": "Update an existing SNI endpoint.",
-          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/sni-endpoints/{(%23%2Fdefinitions%2Fsni-endpoint%2Fdefinitions%2Fidentity)}",
-          "method": "PATCH",
-          "rel": "update",
-          "schema": {
-            "properties": {
-              "certificate_chain": {
-                "$ref": "#/definitions/sni-endpoint/definitions/certificate_chain"
-              },
-              "private_key": {
-                "$ref": "#/definitions/sni-endpoint/definitions/private_key"
-              }
-            },
-            "required": [
-              "certificate_chain",
-              "private_key"
-            ],
-            "type": [
-              "object"
-            ]
-          },
-          "targetSchema": {
-            "$ref": "#/definitions/sni-endpoint"
-          },
-          "title": "Update"
-        }
-      ],
-      "properties": {
-        "certificate_chain": {
-          "$ref": "#/definitions/sni-endpoint/definitions/certificate_chain"
-        },
-        "cname": {
-          "$ref": "#/definitions/sni-endpoint/definitions/cname"
-        },
-        "created_at": {
-          "$ref": "#/definitions/sni-endpoint/definitions/created_at"
-        },
-        "id": {
-          "$ref": "#/definitions/sni-endpoint/definitions/id"
-        },
-        "name": {
-          "$ref": "#/definitions/sni-endpoint/definitions/name"
-        },
-        "updated_at": {
-          "$ref": "#/definitions/sni-endpoint/definitions/updated_at"
-        },
-        "ssl_cert": {
-          "description": "certificate provided by this endpoint",
-          "properties": {
-            "ca_signed?": {
-              "$ref": "#/definitions/sni-endpoint/definitions/ca_signed?"
-            },
-            "cert_domains": {
-              "$ref": "#/definitions/sni-endpoint/definitions/cert_domains"
-            },
-            "expires_at": {
-              "$ref": "#/definitions/sni-endpoint/definitions/expires_at"
-            },
-            "issuer": {
-              "$ref": "#/definitions/sni-endpoint/definitions/issuer"
-            },
-            "self_signed?": {
-              "$ref": "#/definitions/sni-endpoint/definitions/self_signed?"
-            },
-            "starts_at": {
-              "$ref": "#/definitions/sni-endpoint/definitions/starts_at"
-            },
-            "subject": {
-              "$ref": "#/definitions/sni-endpoint/definitions/subject"
-            }
-          }
+          "$ref": "#/definitions/whitelisted-add-on-service/definitions/id"
         }
       }
     }
@@ -11976,26 +12324,32 @@
     "account": {
       "$ref": "#/definitions/account"
     },
-    "addon-action": {
-      "$ref": "#/definitions/addon-action"
+    "add-on-action": {
+      "$ref": "#/definitions/add-on-action"
     },
-    "addon-attachment": {
-      "$ref": "#/definitions/addon-attachment"
+    "add-on-attachment": {
+      "$ref": "#/definitions/add-on-attachment"
     },
-    "addon-config": {
-      "$ref": "#/definitions/addon-config"
+    "add-on-config": {
+      "$ref": "#/definitions/add-on-config"
     },
-    "addon-region-capability": {
-      "$ref": "#/definitions/addon-region-capability"
+    "add-on-plan-action": {
+      "$ref": "#/definitions/add-on-plan-action"
     },
-    "addon-service": {
-      "$ref": "#/definitions/addon-service"
+    "add-on-region-capability": {
+      "$ref": "#/definitions/add-on-region-capability"
     },
-    "addon": {
-      "$ref": "#/definitions/addon"
+    "add-on-service": {
+      "$ref": "#/definitions/add-on-service"
+    },
+    "add-on": {
+      "$ref": "#/definitions/add-on"
     },
     "app-feature": {
       "$ref": "#/definitions/app-feature"
+    },
+    "app-formation-set": {
+      "$ref": "#/definitions/app-formation-set"
     },
     "app-setup": {
       "$ref": "#/definitions/app-setup"
@@ -12027,6 +12381,9 @@
     "domain": {
       "$ref": "#/definitions/domain"
     },
+    "dyno-size": {
+      "$ref": "#/definitions/dyno-size"
+    },
     "dyno": {
       "$ref": "#/definitions/dyno"
     },
@@ -12041,6 +12398,9 @@
     },
     "formation": {
       "$ref": "#/definitions/formation"
+    },
+    "identity-provider": {
+      "$ref": "#/definitions/identity-provider"
     },
     "inbound-ruleset": {
       "$ref": "#/definitions/inbound-ruleset"
@@ -12075,8 +12435,8 @@
     "oauth-token": {
       "$ref": "#/definitions/oauth-token"
     },
-    "organization-addon": {
-      "$ref": "#/definitions/organization-addon"
+    "organization-add-on": {
+      "$ref": "#/definitions/organization-add-on"
     },
     "organization-app-collaborator": {
       "$ref": "#/definitions/organization-app-collaborator"
@@ -12084,14 +12444,17 @@
     "organization-app": {
       "$ref": "#/definitions/organization-app"
     },
+    "organization-feature": {
+      "$ref": "#/definitions/organization-feature"
+    },
+    "organization-invitation": {
+      "$ref": "#/definitions/organization-invitation"
+    },
     "organization-invoice": {
       "$ref": "#/definitions/organization-invoice"
     },
     "organization-member": {
       "$ref": "#/definitions/organization-member"
-    },
-    "organization-payment-method": {
-      "$ref": "#/definitions/organization-payment-method"
     },
     "organization-preferences": {
       "$ref": "#/definitions/organization-preferences"
@@ -12099,20 +12462,11 @@
     "organization": {
       "$ref": "#/definitions/organization"
     },
-    "otp-secret": {
-      "$ref": "#/definitions/otp-secret"
-    },
     "outbound-ruleset": {
       "$ref": "#/definitions/outbound-ruleset"
     },
     "password-reset": {
       "$ref": "#/definitions/password-reset"
-    },
-    "payment-method": {
-      "$ref": "#/definitions/payment-method"
-    },
-    "payment": {
-      "$ref": "#/definitions/payment"
     },
     "organization-app-permission": {
       "$ref": "#/definitions/organization-app-permission"
@@ -12135,9 +12489,6 @@
     "rate-limit": {
       "$ref": "#/definitions/rate-limit"
     },
-    "recovery-code": {
-      "$ref": "#/definitions/recovery-code"
-    },
     "region": {
       "$ref": "#/definitions/region"
     },
@@ -12149,6 +12500,9 @@
     },
     "sms-number": {
       "$ref": "#/definitions/sms-number"
+    },
+    "sni-endpoint": {
+      "$ref": "#/definitions/sni-endpoint"
     },
     "source": {
       "$ref": "#/definitions/source"
@@ -12171,11 +12525,8 @@
     "user-preferences": {
       "$ref": "#/definitions/user-preferences"
     },
-    "whitelisted-addon-service": {
-      "$ref": "#/definitions/whitelisted-addon-service"
-    },
-    "sni-endpoint": {
-      "$ref": "#/definitions/sni-endpoint"
+    "whitelisted-add-on-service": {
+      "$ref": "#/definitions/whitelisted-add-on-service"
     }
   },
   "description": "The platform API empowers developers to automate, extend and combine Heroku with other services.",


### PR DESCRIPTION
A patch version bump of heroics now raises an exception if the `schema.json` is going to convert to an invalid Ruby method (https://github.com/interagent/heroics/pull/78).

My previous hotfix (https://github.com/jalada/platform-api/commit/b165a4c8a82c194be6e8c6b4cde378f9c7d2cf71) to remove the syntax error was no longer enough, as per @tgmerritt's PR: https://github.com/jalada/platform-api/pull/1.

I've regenerated the entire gem from the latest Heroku API schema, where they also removed the brackets to circumvent this issue.

Fixes https://github.com/jalada/platform-api/pull/1 and https://github.com/pixielabs/letsencrypt-rails-heroku/issues/35